### PR TITLE
Force precedence ordering where it makes sense

### DIFF
--- a/doc/baseclass.rst
+++ b/doc/baseclass.rst
@@ -27,13 +27,13 @@ For example, for a simple polynomial with scalar coefficients:
     >>> x, y = numpoly.symbols("x y")
     >>> poly = numpoly.polynomial(4*x+3*y-1)
     >>> poly
-    polynomial(-1+3*y+4*x)
+    polynomial(-1+4*x+3*y)
     >>> poly.coefficients
-    [-1, 3, 4]
+    [-1, 4, 3]
     >>> poly.exponents
     array([[0, 0],
-           [0, 1],
-           [1, 0]], dtype=uint32)
+           [1, 0],
+           [0, 1]], dtype=uint32)
     >>> poly.indeterminants
     polynomial([x, y])
 
@@ -44,7 +44,7 @@ These three properties can be used to reconstruct the polynomial:
     >>> terms = numpoly.prod(
     ...     poly.indeterminants**poly.exponents, -1)*poly.coefficients
     >>> terms
-    polynomial([-1, 3*y, 4*x])
+    polynomial([-1, 4*x, 3*y])
     >>> numpoly.sum(terms, 0)
     polynomial(-1+3*y+4*x)
 
@@ -57,14 +57,14 @@ in it's true form:
     >>> dtype = [(key, poly.dtype) for key in poly.keys]
     >>> array = numpy.ndarray(shape=poly.shape, dtype=dtype, buffer=poly.data)
     >>> array  # doctest: +NORMALIZE_WHITESPACE
-    array((-1, 3, 4),
-          dtype=[('00', '<i8'), ('01', '<i8'), ('10', '<i8')])
+    array((-1, 4, 3),
+          dtype=[('00', '<i8'), ('10', '<i8'), ('01', '<i8')])
 
 Which, together with the indeterminant names, can be cast back to a polynomial:
 
 .. code:: python
 
     >>> numpoly.aspolynomial(array, indeterminants=("x", "y"))
-    polynomial(-1+3*y+4*x)
+    polynomial(-1+4*x+3*y)
 
 .. autoclass:: numpoly.baseclass.ndpoly

--- a/numpoly/align.py
+++ b/numpoly/align.py
@@ -31,7 +31,7 @@ def align_polynomials(*polys):
         >>> x
         polynomial([x, x])
         >>> x.coefficients
-        [array([0., 0.]), array([1., 1.])]
+        [array([1., 1.]), array([0., 0.])]
         >>> x.indeterminants
         polynomial([x, y])
 
@@ -181,14 +181,14 @@ def align_exponents(*polys):
         >>> print(poly2)
         [x**5 -1+y**3]
         >>> print(poly1.exponents)
-        [[0 0]
+        [[1 1]
+         [0 0]
          [0 3]
-         [1 1]
          [5 0]]
         >>> print(poly2.exponents)
-        [[0 0]
+        [[1 1]
+         [0 0]
          [0 3]
-         [1 1]
          [5 0]]
 
     """
@@ -199,8 +199,12 @@ def align_exponents(*polys):
     ):
         polys = list(align_indeterminants(*polys))
 
-    global_exponents = sorted({
-        tuple(exponent) for poly in polys for exponent in poly.exponents})
+    global_exponents = [tuple(exponent) for exponent in polys[0].exponents]
+    for poly in polys[1:]:
+        global_exponents.extend([tuple(exponent)
+                                 for exponent in poly.exponents
+                                 if tuple(exponent) not in global_exponents])
+
     for idx, poly in enumerate(polys):
         lookup = {
             tuple(exponent): coefficient

--- a/numpoly/array_function/add.py
+++ b/numpoly/array_function/add.py
@@ -39,13 +39,13 @@ def add(x1, x2, out=None, where=True, **kwargs):
     Examples:
         >>> x, y = numpoly.symbols("x y")
         >>> numpoly.add(x, 4)
-        polynomial(4+x)
+        polynomial(x+4)
         >>> poly1 = x**numpy.arange(9).reshape((3, 3))
         >>> poly2 = y**numpy.arange(3)
         >>> numpoly.add(poly1, poly2)
-        polynomial([[2, y+x, y**2+x**2],
-                    [1+x**3, y+x**4, y**2+x**5],
-                    [1+x**6, y+x**7, y**2+x**8]])
+        polynomial([[2, x+y, x**2+y**2],
+                    [1+x**3, x**4+y, x**5+y**2],
+                    [1+x**6, x**7+y, x**8+y**2]])
 
     """
     return simple_dispatch(

--- a/numpoly/array_function/allclose.py
+++ b/numpoly/array_function/allclose.py
@@ -58,7 +58,8 @@ def allclose(a, b, rtol=1e-5, atol=1e-8, equal_nan=False):
         True
         >>> numpoly.allclose([1e10*x, 1e-8], [1.00001e10*y, 1e-9])
         False
-        >>> numpoly.allclose([x, numpy.nan], [x, numpy.nan], equal_nan=True)
+        >>> numpoly.allclose([x, numpy.nan],
+        ...                  [x, numpy.nan], equal_nan=True)
         True
 
     """

--- a/numpoly/array_function/common_type.py
+++ b/numpoly/array_function/common_type.py
@@ -27,9 +27,11 @@ def common_type(*arrays):
             Data type code.
 
     Examples:
-        >>> numpoly.common_type(numpy.array(2, dtype=numpy.float32)).__name__
+        >>> numpoly.common_type(
+        ...     numpy.array(2, dtype=numpy.float32)).__name__
         'float32'
-        >>> numpoly.common_type(numpoly.symbols("x")).__name__
+        >>> numpoly.common_type(
+        ...     numpoly.symbols("x")).__name__
         'float64'
         >>> numpoly.common_type(
         ...     numpy.arange(3), 1j*numpoly.symbols("x"), 45).__name__

--- a/numpoly/array_function/cumsum.py
+++ b/numpoly/array_function/cumsum.py
@@ -41,9 +41,9 @@ def cumsum(a, axis=None, dtype=None, out=None):
         polynomial([[1, x, 3],
                     [4, 5, y]])
         >>> numpoly.cumsum(poly)
-        polynomial([1, 1+x, 4+x, 8+x, 13+x, 13+y+x])
+        polynomial([1, 1+x, 4+x, 8+x, 13+x, 13+x+y])
         >>> numpoly.cumsum(poly, dtype=float)
-        polynomial([1.0, 1.0+x, 4.0+x, 8.0+x, 13.0+x, 13.0+y+x])
+        polynomial([1.0, 1.0+x, 4.0+x, 8.0+x, 13.0+x, 13.0+x+y])
         >>> numpoly.cumsum(poly, axis=0)
         polynomial([[1, x, 3],
                     [5, 5+x, 3+y]])

--- a/numpoly/array_function/isclose.py
+++ b/numpoly/array_function/isclose.py
@@ -59,7 +59,8 @@ def isclose(a, b, rtol=1e-5, atol=1e-8, equal_nan=False):
         array([ True,  True])
         >>> numpoly.isclose([1e10*x, 1e-8], [1.00001e10*y, 1e-9])
         array([False,  True])
-        >>> numpoly.isclose([x, numpy.nan], [x, numpy.nan], equal_nan=True)
+        >>> numpoly.isclose([x, numpy.nan],
+        ...                 [x, numpy.nan], equal_nan=True)
         array([ True,  True])
 
     """

--- a/numpoly/array_function/mean.py
+++ b/numpoly/array_function/mean.py
@@ -47,11 +47,11 @@ def mean(a, axis=None, dtype=None, out=None, **kwargs):
         >>> x, y = numpoly.symbols("x y")
         >>> a = numpoly.polynomial([[1, 2*x], [3*y+x, 4]])
         >>> numpoly.mean(a)
-        polynomial(1.25+0.75*y+0.75*x)
+        polynomial(1.25+0.75*x+0.75*y)
         >>> numpoly.mean(a, axis=0)
-        polynomial([0.5+1.5*y+0.5*x, 2.0+x])
+        polynomial([0.5+0.5*x+1.5*y, 2.0+x])
         >>> numpoly.mean(a, axis=1)
-        polynomial([0.5+x, 2.0+1.5*y+0.5*x])
+        polynomial([0.5+x, 2.0+0.5*x+1.5*y])
 
     """
     return simple_dispatch(

--- a/numpoly/array_function/subtract.py
+++ b/numpoly/array_function/subtract.py
@@ -39,7 +39,7 @@ def subtract(x1, x2, out=None, where=True, **kwargs):
     Examples:
         >>> x, y = numpoly.symbols("x y")
         >>> numpoly.subtract(x, 4)
-        polynomial(-4+x)
+        polynomial(x-4)
         >>> poly1 = y**numpy.arange(3)
         >>> poly2 = x**numpy.arange(9).reshape((3, 3))
         >>> numpoly.subtract(poly1, poly2)

--- a/numpoly/array_function/sum.py
+++ b/numpoly/array_function/sum.py
@@ -49,11 +49,11 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=False, **kwargs):
     Examples:
         >>> x, y, z = xyz = numpoly.symbols("x y z")
         >>> numpoly.sum(xyz)
-        polynomial(z+y+x)
+        polynomial(x+y+z)
         >>> numpoly.sum([[1, x], [y, z]])
-        polynomial(1+z+y+x)
+        polynomial(1+x+z+y)
         >>> numpoly.sum([[1, x], [y, z]], axis=0)
-        polynomial([1+y, z+x])
+        polynomial([1+y, x+z])
 
     """
     return simple_dispatch(

--- a/numpoly/baseclass.py
+++ b/numpoly/baseclass.py
@@ -45,7 +45,8 @@ class ndpoly(numpy.ndarray):  # pylint: disable=invalid-name
     memory, whether it is an integer, a floating point number, or something
     else, etc.)
 
-    Arrays should be constructed using `polynomial`, `symbols` etc.
+    Arrays should be constructed using `symbols`, `monomials`, `polynomial`,
+    etc.
 
     Attributes:
         coefficients (List[numpy.ndarray, ...]):
@@ -303,7 +304,19 @@ class ndpoly(numpy.ndarray):  # pylint: disable=invalid-name
 
     @property
     def values(self):
-        """Expose the underlying structured array."""
+        """
+        Expose the underlying structured array.
+
+        Typically used for operator dispatching and not for use to conversion.
+        For that, see :func:`numpoly.tonumpy`.
+
+        Examples:
+            >>> numpoly.symbols("x").values
+            array((1,), dtype=[('1', '<i8')])
+            >>> numpoly.symbols("x y").values
+            array([(1, 0), (0, 1)], dtype=[('10', '<i8'), ('01', '<i8')])
+
+        """
         return numpy.ndarray(
             shape=self.shape,
             dtype=[(key, self.dtype) for key in self.keys],
@@ -343,9 +356,9 @@ class ndpoly(numpy.ndarray):  # pylint: disable=invalid-name
             >>> x, y = numpoly.symbols("x y")
             >>> poly = 2*x**4-3*y**2+14
             >>> print(poly)
-            14-3*y**2+2*x**4
-            >>> print(poly.todict())
-            {(0, 0): 14, (0, 2): -3, (4, 0): 2}
+            14+2*x**4-3*y**2
+            >>> poly.todict() == {(0, 0): 14, (4, 0): 2, (0, 2): -3}
+            True
 
         """
         return {tuple(exponent): coefficient

--- a/numpoly/construct/compose.py
+++ b/numpoly/construct/compose.py
@@ -39,7 +39,7 @@ def compose_polynomial_array(
     indices = numpy.array([isinstance(array, numpoly.ndpoly)
                            for array in arrays])
     arrays[indices] = numpoly.align_indeterminants(*arrays[indices])
-    indeterminants = arrays[indices][0] if numpy.any(indices) else "q"
+    indeterminants = arrays[indices][0] if numpy.any(indices) else None
     arrays = arrays.tolist()
 
     dtypes = []

--- a/numpoly/construct/from_attributes.py
+++ b/numpoly/construct/from_attributes.py
@@ -33,9 +33,23 @@ def polynomial_from_attributes(
             Clean up attributes, removing redundant indeterminants and
             exponents.
 
-    Examples:
+    Returns:
         (numpoly.ndpoly):
             Polynomial array with attributes determined by the input.
+
+    Examples:
+        >>> numpoly.ndpoly.from_attributes(
+        ...     exponents=[(0,), (1,)],
+        ...     coefficients=[[1, 0], [0, 1]],
+        ...     indeterminants=("x",),
+        ... )
+        polynomial([1, x])
+        >>> numpoly.ndpoly.from_attributes(
+        ...     exponents=[(0, 0, 0), (1, 1, 2)],
+        ...     coefficients=[4, -1],
+        ...     indeterminants=("x", "y", "z"),
+        ... )
+        polynomial(4-x*y*z**2)
 
     """
     if clean:

--- a/numpoly/construct/polynomial.py
+++ b/numpoly/construct/polynomial.py
@@ -46,8 +46,9 @@ def polynomial(
         q
         >>> x, y = numpoly.symbols("x y")
         >>> print(x**2 + x*y + 2)
-        2+x*y+x**2
-        >>> poly = -3*x + x**2 + y
+        x**2+x*y+2
+        >>> print(-3*x + x**2 + y)
+        -3*x+x**2+y
         >>> print(numpoly.polynomial([x*y, x, y]))
         [x*y x y]
         >>> print(numpoly.polynomial([1, 2, 3]))

--- a/numpoly/poly_function/call.py
+++ b/numpoly/poly_function/call.py
@@ -27,7 +27,7 @@ def call(poly, *args, **kwargs):
         >>> poly = numpoly.polynomial([[x, x-1], [y, y+x]])
         >>> print(poly)
         [[x -1+x]
-         [y y+x]]
+         [y x+y]]
         >>> print(poly(1, 0))
         [[1 0]
          [0 1]]

--- a/numpoly/poly_function/monomial.py
+++ b/numpoly/poly_function/monomial.py
@@ -22,18 +22,18 @@ def monomial(start, stop=None, ordering="G", cross_truncation=1., indeterminants
         ordering (str):
             The monomial ordering where the letters ``G``, ``I`` and ``R`` can
             be used to set grade, inverse and reverse to the ordering. For
-            ``monomial(("x", "y"), start=0, stop=2, ordering=ordering)`` we
-            get:
+            ``indeterminants=("x", "y"))`` we get for various values for
+            ``ordering``:
 
-            ========  ==================
+            ========  =====================
             ordering  output
-            ========  ==================
-            ""        [1 y y^2 x xy x^2]
-            "G"       [1 y x y^2 xy x^2]
-            "I"       [x^2 xy x y^2 y 1]
-            "R"       [1 x x^2 y xy y^2]
-            "GIR"     [y^2 xy x^2 y x 1]
-            ========  ==================
+            ========  =====================
+            ""        [1 y y**2 x x*y x**2]
+            "G"       [1 y x y**2 x*y x**2]
+            "I"       [x**2 x*y x y**2 y 1]
+            "R"       [1 x x**2 y x*y y**2]
+            "GIR"     [y**2 x*y x**2 y x 1]
+            ========  =====================
         cross_truncation (float):
             Use hyperbolic cross truncation scheme to reduce the number of
             terms in expansion.
@@ -48,7 +48,7 @@ def monomial(start, stop=None, ordering="G", cross_truncation=1., indeterminants
         >>> print(numpoly.monomial(4))
         [1 q q**2 q**3 q**4]
         >>> print(numpoly.monomial(4, 4, ordering="GR", indeterminants=("x", "y")))
-        [x**4 x**3*y y**4 x**2*y**2 x*y**3]
+        [x**4 x**3*y x**2*y**2 x*y**3 y**4]
         >>> print(numpoly.monomial([1, 1], [2, 2], indeterminants=("x", "y")))
         [x*y x*y**2 x**2*y x**2*y**2]
 
@@ -151,7 +151,7 @@ def bindex(start, stop=None, dimensions=1, ordering="G", cross_truncation=1.):
 
     indices = _bindex(start, stop, dimensions, cross_truncation)
     if "G" in ordering:
-        indices = indices[numpy.argsort(numpy.sum(indices, -1))]
+        indices = indices[numpy.lexsort([numpy.sum(indices, -1)])]
 
     if "I" in ordering:
         indices = indices[::-1]

--- a/numpoly/poly_function/symbols.py
+++ b/numpoly/poly_function/symbols.py
@@ -6,7 +6,7 @@ import numpy
 import numpoly
 
 
-def symbols(names="q", asarray=False, dtype="i8"):
+def symbols(names=None, asarray=False, dtype="i8"):
     """
     Construct symbol variables.
 
@@ -18,7 +18,7 @@ def symbols(names="q", asarray=False, dtype="i8"):
     * ``{letter}:{letter}`` can be used to define a alphabet range.
 
     Args:
-        names (str, Tuple[str, ...]):
+        names (None, str, Tuple[str, ...]):
             Indeterminants are determined by splitting the string on space. If
             iterable of strings, indeterminants defined directly.
         asarray (bool):
@@ -32,12 +32,12 @@ def symbols(names="q", asarray=False, dtype="i8"):
             Polynomial array with unit components in each dimension.
 
     Examples:
-        >>> print(numpoly.symbols("q"))
+        >>> print(numpoly.symbols())
         q
-        >>> print(numpoly.symbols("q,"))
-        [q]
-        >>> print(numpoly.symbols("q", asarray=True))
-        [q]
+        >>> print(numpoly.symbols("z,"))
+        [z]
+        >>> print(numpoly.symbols("z", asarray=True))
+        [z]
         >>> print(numpoly.symbols(["alpha", "beta"]))
         [alpha beta]
         >>> print(numpoly.symbols("x y z"))
@@ -52,6 +52,11 @@ def symbols(names="q", asarray=False, dtype="i8"):
         [za zb zc zd ze zf]
 
     """
+    if names is None:
+        coefficients = numpy.ones((1, 1) if asarray else 1, dtype=dtype)
+        return numpoly.ndpoly.from_attributes(
+            exponents=[(1,)], coefficients=coefficients)
+
     if not isinstance(names, str):
         names = list(names)
 

--- a/numpoly/poly_function/tonumpy.py
+++ b/numpoly/poly_function/tonumpy.py
@@ -32,4 +32,5 @@ def tonumpy(poly):
     if not poly.isconstant():
         raise ValueError(
             "only constant polynomials can be converted to array.")
-    return numpy.array(poly.coefficients[0])
+    idx = numpy.argwhere(numpy.all(poly.exponents == 0, -1)).item()
+    return numpy.array(poly.coefficients[idx])

--- a/test/test_construct.py
+++ b/test/test_construct.py
@@ -1,0 +1,22 @@
+"""Test for `numpoly.construct`."""
+from pytest import raises
+import numpy
+
+from numpoly.construct.clean import (
+    postprocess_attributes, PolynomialConstructionError)
+
+
+def test_postprocess_attributes():
+    """Test related to polynomial construction from attributes."""
+    with raises(PolynomialConstructionError):  # exponent.ndim too small
+        postprocess_attributes(numpy.arange(2), [1, 2])
+    with raises(PolynomialConstructionError):  # exponent.ndim too large
+        postprocess_attributes(numpy.arange(24).reshape(2, 3, 4), [1, 2])
+    with raises(PolynomialConstructionError):  # exponents len incompatible with coefficients
+        postprocess_attributes(numpy.arange(6).reshape(2, 3), [1, 2, 3])
+    with raises(PolynomialConstructionError):  # duplicate exponents
+        postprocess_attributes([[1], [1]], [1, 2])
+    with raises(PolynomialConstructionError):  # exponents len incompatible with indeterminants
+        postprocess_attributes([[1], [2]], [1, 2], ["x", "y", "z"])
+    with raises(PolynomialConstructionError):  # duplicate indeterminant names
+        postprocess_attributes([[1], [2]], [1, 2], ["x", "x"])


### PR DESCRIPTION
This means that we get:

    x+y -> x+y
    y+x -> y+x

But because of how coefficients are stored, only one ordering is allowed
per array. E.g.:

    [x+y, y+x] -> [x+y, x+y]