### PR TITLE
Enforce q\d notation be default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,41 +69,41 @@ constructors:
 
 .. code-block:: python
 
-    >>> numpoly.monomial(start=0, stop=4, names=("x", "y"))
-    polynomial([1, x, x**2, x**3, y, x*y, x**2*y, y**2, x*y**2, y**3])
+    >>> numpoly.monomial(start=0, stop=3, names=2)
+    polynomial([1, q0, q0**2, q1, q0*q1, q1**2])
 
 It is also possible to construct your own from symbols:
 
 .. code-block:: python
 
-    >>> x, y = numpoly.symbols("x y")
-    >>> numpoly.polynomial([1, x**2-1, x*y, y**2-1])
-    polynomial([1, x**2-1, x*y, y**2-1])
+    >>> q0, q1 = numpoly.variable(2)
+    >>> numpoly.polynomial([1, q0**2-1, q0*q1, q1**2-1])
+    polynomial([1, q0**2-1, q0*q1, q1**2-1])
 
 Or in combination with numpy objects using various arithmetics:
 
 .. code-block:: python
 
-    >>> x**numpy.arange(4)-y**numpy.arange(3, -1, -1)
-    polynomial([-y**3+1, -y**2+x, x**2-y, x**3-1])
+    >>> q0**numpy.arange(4)-q1**numpy.arange(3, -1, -1)
+    polynomial([-q1**3+1, -q1**2+q0, q0**2-q1, q0**3-1])
 
 The constructed polynomials can be evaluated as needed:
 
 .. code-block:: python
 
-    >>> poly = 3*x+2*y+1
-    >>> poly(x=y, y=[1, 2, 3])
-    polynomial([3*y+3, 3*y+5, 3*y+7])
+    >>> poly = 3*q0+2*q1+1
+    >>> poly(q0=q1, q1=[1, 2, 3])
+    polynomial([3*q1+3, 3*q1+5, 3*q1+7])
 
 Or manipulated using various numpy functions:
 
 .. code-block:: python
 
-    >>> numpy.reshape(x**numpy.arange(4), (2, 2))
-    polynomial([[1, x],
-                [x**2, x**3]])
-    >>> numpy.sum(numpoly.monomial(13, names="z")[::3])
-    polynomial(z**12+z**9+z**6+z**3+1)
+    >>> numpy.reshape(q0**numpy.arange(4), (2, 2))
+    polynomial([[1, q0],
+                [q0**2, q0**3]])
+    >>> numpy.sum(numpoly.monomial(13)[::3])
+    polynomial(q0**12+q0**9+q0**6+q0**3+1)
 
 Development
 -----------

--- a/doc/array_function.rst
+++ b/doc/array_function.rst
@@ -15,13 +15,13 @@ For example:
 
 .. code:: python
 
-    >>> poly = numpoly.symbols("x")**numpy.arange(4)
+    >>> poly = numpoly.variable()**numpy.arange(4)
     >>> print(poly)
-    [1 x x**2 x**3]
+    [1 q0 q0**2 q0**3]
     >>> print(numpoly.sum(poly, keepdims=True))
-    [x**3+x**2+x+1]
+    [q0**3+q0**2+q0+1]
     >>> print(numpy.sum(poly, keepdims=True)) # doctest: +SKIP
-    [x**3+x**2+x+1]
+    [q0**3+q0**2+q0+1]
 
 For earlier versions of numpy, the last line will not work.
 

--- a/doc/comparison.rst
+++ b/doc/comparison.rst
@@ -33,8 +33,8 @@ The default ordering implemented in ``numpoly`` is defined as follows:
 
   .. code:: python
 
-    >>> x = numpoly.symbols("x")
-    >>> x < x**2 < x**3
+    >>> q0 = numpoly.variable()
+    >>> q0 < q0**2 < q0**3
     True
 
   If the largest polynomial in one polynomial is larger than in another,
@@ -42,7 +42,7 @@ The default ordering implemented in ``numpoly`` is defined as follows:
 
   .. code:: python
 
-    >>> 4*x < 3*x**2 < 2*x**3
+    >>> 4*q0 < 3*q0**2 < 2*q0**3
     True
 
   In the multivariate case, the polynomial order is determined by the sum of
@@ -50,8 +50,8 @@ The default ordering implemented in ``numpoly`` is defined as follows:
 
   .. code:: python
 
-    >>> x, y, z = numpoly.symbols("x y z")
-    >>> x**2*y**2 < x*y**5 < x**6*y
+    >>> q0, q1 = numpoly.variable(2)
+    >>> q0**2*q1**2 < q0*q1**5 < q0**6*q1
     True
 
   This implies that given higher polynomial order, indeterminant names are
@@ -59,14 +59,15 @@ The default ordering implemented in ``numpoly`` is defined as follows:
 
   .. code:: python
 
-    >>> x < z**2 < y**3
+    >>> q0, q1, q2 = numpoly.variable(3)
+    >>> q0 < q2**2 < q1**3
     True
 
   The same goes for any polynomial terms which are not leading:
 
   .. code:: python
 
-    >>> 4*x < x**2+3*x < x**3+2*x
+    >>> 4*q0 < q0**2+3*q0 < q0**3+2*q0
     True
 
 
@@ -74,14 +75,14 @@ The default ordering implemented in ``numpoly`` is defined as follows:
 
   .. code:: python
 
-    >>> x < y < z
+    >>> q0 < q1 < q2
     True
 
   As with polynomial order, coefficients and lower order terms are ignored:
 
   .. code:: python
 
-    >>> 4*x**3+4*x < 3*y**3+3*y < 2*z**3+2*z
+    >>> 4*q0**3+4*q0 < 3*q1**3+3*q1 < 2*q2**3+2*q2
     True
 
   Composite polynomials of the same order are sorted by lexicographically by
@@ -89,7 +90,7 @@ The default ordering implemented in ``numpoly`` is defined as follows:
 
   .. code:: python
 
-    >>> x**3*y < x**2*y**2 < x*y**3
+    >>> q0**3*q1 < q0**2*q1**2 < q0*q1**3
     True
 
   If there are more than two, and the dominant order first addresses the first,
@@ -97,7 +98,7 @@ The default ordering implemented in ``numpoly`` is defined as follows:
 
   .. code:: python
 
-    >>> x**2*y**2*z < x**2*y*z**2 < x*y**2*z**2
+    >>> q0**2*q1**2*q2 < q0**2*q1*q2**2 < q0*q1**2*q2**2
     True
 
 * Polynomials that have exactly the same leading polynomial, are compared by
@@ -105,7 +106,7 @@ The default ordering implemented in ``numpoly`` is defined as follows:
 
   .. code:: python
 
-    >>> -4*x < -1*x < 2*x
+    >>> -4*q0 < -1*q0 < 2*q0
     True
 
   This notion implies that constant polynomial, the same way as ``numpy``
@@ -121,7 +122,7 @@ The default ordering implemented in ``numpoly`` is defined as follows:
 
   .. code:: python
 
-    >>> x**2+1 < x**2+2 < x**2+3
+    >>> q0**2+1 < q0**2+2 < q0**2+3
     True
 
   And if both the first two leading terms are the same, use the third and so
@@ -129,7 +130,7 @@ The default ordering implemented in ``numpoly`` is defined as follows:
 
   .. code:: python
 
-    >>> x**2+x+1 < x**2+x+2 < x**2+x+3
+    >>> q0**2+q0+1 < q0**2+q0+2 < q0**2+q0+3
     True
 
   Unlike for the leading polynomial term, missing terms are considered present
@@ -137,7 +138,7 @@ The default ordering implemented in ``numpoly`` is defined as follows:
 
   .. code:: python
 
-    >>> x**2-1 < x**2 < x**2+1
+    >>> q0**2-1 < q0**2 < q0**2+1
     True
 
 These rules together allow for a total comparison for all polynomials.
@@ -151,10 +152,10 @@ behavior. In particular:
 
 ``sort_graded``
   Impose that polynomials are sorted by grade, meaning the indices are always
-  sorted by the index sum. E.g. ``x**2*y**2*z**2`` has an exponent sum of 6,
-  and will therefore be consider larger than both ``x**3*y*z``, ``x*y**3*z``
-  and ``x*y*z**3``. Defaults to true.
+  sorted by the index sum. E.g. ``q0**2*q1**2*q2**2`` has an exponent sum of 6,
+  and will therefore be consider larger than both ``q0**3*q1*q2``,
+  ``q0*q1**3*q2`` and ``q0*q1*q2**3``. Defaults to true.
 ``sort_reverse``
   Impose that polynomials are sorted by reverses lexicographical sorting,
-  meaning that ``x*y**3`` is considered smaller than ``x**3*y``, instead of the
+  meaning that ``q0*q1**3`` is considered smaller than ``q0**3*q1``, instead of the
   opposite. Defaults to false.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -202,5 +202,5 @@ epub_exclude_files = ['search.html']
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
 }

--- a/doc/division.rst
+++ b/doc/division.rst
@@ -36,12 +36,12 @@ not round values:
 
 .. code:: python
 
-    >>> x, y = numpoly.symbols("x y")
-    >>> dividend = x**2+y
-    >>> divisor = x-1
+    >>> q0, q1 = numpoly.variable(2)
+    >>> dividend = q0**2+q1
+    >>> divisor = q0-1
     >>> quotient = numpoly.poly_divide(dividend, divisor)
     >>> quotient
-    polynomial(x+1.0)
+    polynomial(q0+1.0)
 
 However, like floor division, it can still have remainders.
 For example:
@@ -50,7 +50,7 @@ For example:
 
     >>> remainder = numpoly.poly_remainder(dividend, divisor)
     >>> remainder
-    polynomial(y+1.0)
+    polynomial(q1+1.0)
     >>> dividend == quotient*divisor+remainder
     True
 

--- a/doc/initialization.rst
+++ b/doc/initialization.rst
@@ -5,18 +5,18 @@ The core element of the `numpoly` library is the `numpoly.ndpoly` class. The
 class is subclass of of the `numpy.ndarray` and the implementation follows the
 recommendation of how to subclass `numpy` objects.
 
-In a nutshell, the `nmply.ndpoly` under the hood is a structured array, where
+In a nutshell, the `numpoly.ndpoly` under the hood is a structured array, where
 the column names represents the exponent powers as strings, and the values
 represents the coefficients. In other words, the polynomial coefficients are
 represented as `numpy.ndarray`:
 
 .. math::
 
-    \Phi(x_1, \dots, x_D) = \sum_{n=1}^N c_n x_1^{k_{1n}} \cdots x_D^{k_{Dn}}
+    \Phi(q_1, \dots, q_D) = \sum_{n=1}^N c_n q_1^{k_{1n}} \cdots q_D^{k_{Dn}}
 
-Where :math:`\Phi` is polynomial vector, :math:`N` is the number of terms in the
-polynomial sum, :math:`c_n` is a (potentially) multi-dimensional polynomial
-coefficients, :math:`x_d` is the :math:`d`-th indeterminant name, and
+Where :math:`\Phi` is polynomial vector, :math:`N` is the number of terms in
+the polynomial sum, :math:`c_n` is a (potentially) multi-dimensional polynomial
+coefficients, :math:`q_d` is the :math:`d`-th indeterminant name, and
 :math:`k_{nd}` is the exponent for the :math:`n`-th polynomial term and the
 :math:`d`-th indeterminant name.
 
@@ -24,10 +24,10 @@ For example, for a simple polynomial with scalar coefficients:
 
 .. code:: python
 
-    >>> x, y = numpoly.symbols("x y")
-    >>> poly = numpoly.polynomial(4*x+3*y-1)
+    >>> q0, q1 = numpoly.variable(2)
+    >>> poly = numpoly.polynomial(4*q0+3*q1-1)
     >>> poly
-    polynomial(3*y+4*x-1)
+    polynomial(3*q1+4*q0-1)
     >>> poly.coefficients
     [-1, 4, 3]
     >>> poly.exponents
@@ -35,7 +35,7 @@ For example, for a simple polynomial with scalar coefficients:
            [1, 0],
            [0, 1]], dtype=uint32)
     >>> poly.indeterminants
-    polynomial([x, y])
+    polynomial([q0, q1])
 
 These three properties can be used to reconstruct the polynomial:
 
@@ -44,9 +44,9 @@ These three properties can be used to reconstruct the polynomial:
     >>> terms = numpoly.prod(
     ...     poly.indeterminants**poly.exponents, -1)*poly.coefficients
     >>> terms
-    polynomial([-1, 4*x, 3*y])
+    polynomial([-1, 4*q0, 3*q1])
     >>> numpoly.sum(terms, 0)
-    polynomial(3*y+4*x-1)
+    polynomial(3*q1+4*q0-1)
 
 Underlying Structured Array
 ---------------------------
@@ -71,8 +71,8 @@ array back to a polynomial:
 
 .. code:: python
 
-    >>> numpoly.aspolynomial(array, names=("x", "y"))
-    polynomial(3*y+4*x-1)
+    >>> numpoly.aspolynomial(array, names=("q0", "q1"))
+    polynomial(3*q1+4*q0-1)
 
 Constructors
 ------------

--- a/numpoly/__init__.py
+++ b/numpoly/__init__.py
@@ -20,6 +20,7 @@ from .construct import (
     polynomial_from_attributes,
     monomial,
     symbols,
+    variable,
 )
 from .sympy_ import to_sympy
 

--- a/numpoly/align.py
+++ b/numpoly/align.py
@@ -20,20 +20,20 @@ def align_polynomials(*polys):
             compatible for further operations.
 
     Examples:
-        >>> x, _ = xy = numpoly.symbols("x y")
-        >>> x
-        polynomial(x)
-        >>> x.coefficients
+        >>> q0, _ = q0q1 = numpoly.variable(2)
+        >>> q0
+        polynomial(q0)
+        >>> q0.coefficients
         [1]
-        >>> x.indeterminants
-        polynomial([x])
-        >>> x, _ = numpoly.align_polynomials(x, xy.astype(float))
-        >>> x
-        polynomial([x, x])
-        >>> x.coefficients
+        >>> q0.indeterminants
+        polynomial([q0])
+        >>> q0, _ = numpoly.align_polynomials(q0, q0q1.astype(float))
+        >>> q0
+        polynomial([q0, q0])
+        >>> q0.coefficients
         [array([1., 1.]), array([0., 0.])]
-        >>> x.indeterminants
-        polynomial([x, y])
+        >>> q0.indeterminants
+        polynomial([q0, q1])
 
     """
     polys = align_shape(*polys)
@@ -57,18 +57,18 @@ def align_shape(*polys):
             compatible for further operations.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> poly1 = 4*x
-        >>> poly2 = numpoly.polynomial([[2*x+1, 3*x-y]])
+        >>> q0, q1 = numpoly.variable(2)
+        >>> poly1 = 4*q0
+        >>> poly2 = numpoly.polynomial([[2*q0+1, 3*q0-q1]])
         >>> print(poly1.shape)
         ()
         >>> print(poly2.shape)
         (1, 2)
         >>> poly1, poly2 = numpoly.align_shape(poly1, poly2)
         >>> print(poly1)
-        [[4*x 4*x]]
+        [[4*q0 4*q0]]
         >>> print(poly2)
-        [[2*x+1 -y+3*x]]
+        [[2*q0+1 -q1+3*q0]]
         >>> print(poly1.shape)
         (1, 2)
         >>> print(poly2.shape)
@@ -104,21 +104,21 @@ def align_indeterminants(*polys):
             compatible for further operations.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> poly1, poly2 = numpoly.polynomial([2*x+1, 3*x-y])
-        >>> print(poly1.indeterminants)
-        [x]
-        >>> print(poly2.indeterminants)
-        [x y]
+        >>> q0, q1 = numpoly.variable(2)
+        >>> poly1, poly2 = numpoly.polynomial([2*q0+1, 3*q0-q1])
+        >>> poly1.indeterminants
+        polynomial([q0])
+        >>> poly2.indeterminants
+        polynomial([q0, q1])
         >>> poly1, poly2 = numpoly.align_indeterminants(poly1, poly2)
-        >>> print(poly1)
-        2*x+1
-        >>> print(poly2)
-        -y+3*x
-        >>> print(poly1.indeterminants)
-        [x y]
-        >>> print(poly2.indeterminants)
-        [x y]
+        >>> poly1
+        polynomial(2*q0+1)
+        >>> poly2
+        polynomial(-q1+3*q0)
+        >>> poly1.indeterminants
+        polynomial([q0, q1])
+        >>> poly2.indeterminants
+        polynomial([q0, q1])
 
     """
     polys = [numpoly.aspolynomial(poly) for poly in polys]
@@ -167,9 +167,9 @@ def align_exponents(*polys):
             compatible for further operations.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> poly1 = x*y
-        >>> poly2 = numpoly.polynomial([x**5, y**3-1])
+        >>> q0, q1 = numpoly.variable(2)
+        >>> poly1 = q0*q1
+        >>> poly2 = numpoly.polynomial([q0**5, q1**3-1])
         >>> poly1.exponents
         array([[1, 1]], dtype=uint32)
         >>> poly2.exponents
@@ -178,9 +178,9 @@ def align_exponents(*polys):
                [5, 0]], dtype=uint32)
         >>> poly1, poly2 = numpoly.align_exponents(poly1, poly2)
         >>> poly1
-        polynomial(x*y)
+        polynomial(q0*q1)
         >>> poly2
-        polynomial([x**5, y**3-1])
+        polynomial([q0**5, q1**3-1])
         >>> poly1.exponents
         array([[1, 1],
                [0, 0],
@@ -238,10 +238,10 @@ def align_dtype(*polys):
             compatible for further operations.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> x.dtype.name
+        >>> q0 = numpoly.variable()
+        >>> q0.dtype.name
         'int64'
-        >>> poly, _ = numpoly.align_dtype(x, 4.5)
+        >>> poly, _ = numpoly.align_dtype(q0, 4.5)
         >>> poly.dtype.name
         'float64'
 

--- a/numpoly/array_function/absolute.py
+++ b/numpoly/array_function/absolute.py
@@ -36,17 +36,17 @@ def absolute(x, out=None, where=True, **kwargs):
             :math:`\sqrt{a^2+b^2}`. This is a scalar if `x` is a scalar.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> poly = numpoly.polynomial([-1.2, 1.2, -2.3*x, 2.3*x])
+        >>> q0 = numpoly.variable()
+        >>> poly = numpoly.polynomial([-1.2, 1.2, -2.3*q0, 2.3*q0])
         >>> poly
-        polynomial([-1.2, 1.2, -2.3*x, 2.3*x])
+        polynomial([-1.2, 1.2, -2.3*q0, 2.3*q0])
         >>> numpoly.absolute(poly)
-        polynomial([1.2, 1.2, 2.3*x, 2.3*x])
-        >>> poly = numpoly.polynomial([x, 1j*x, (3+4j)*x])
+        polynomial([1.2, 1.2, 2.3*q0, 2.3*q0])
+        >>> poly = numpoly.polynomial([q0, 1j*q0, (3+4j)*q0])
         >>> poly
-        polynomial([x, 1j*x, (3+4j)*x])
+        polynomial([q0, 1j*q0, (3+4j)*q0])
         >>> numpoly.absolute(poly)
-        polynomial([x, x, 5.0*x])
+        polynomial([q0, q0, 5.0*q0])
 
     """
     return simple_dispatch(

--- a/numpoly/array_function/add.py
+++ b/numpoly/array_function/add.py
@@ -37,15 +37,15 @@ def add(x1, x2, out=None, where=True, **kwargs):
             `x1` and `x2` are scalars.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> numpoly.add(x, 4)
-        polynomial(x+4)
-        >>> poly1 = x**numpy.arange(9).reshape((3, 3))
-        >>> poly2 = y**numpy.arange(3)
+        >>> q0, q1 = numpoly.variable(2)
+        >>> numpoly.add(q0, 4)
+        polynomial(q0+4)
+        >>> poly1 = q0**numpy.arange(9).reshape((3, 3))
+        >>> poly2 = q1**numpy.arange(3)
         >>> numpoly.add(poly1, poly2)
-        polynomial([[2, y+x, y**2+x**2],
-                    [x**3+1, x**4+y, x**5+y**2],
-                    [x**6+1, x**7+y, x**8+y**2]])
+        polynomial([[2, q1+q0, q1**2+q0**2],
+                    [q0**3+1, q0**4+q1, q0**5+q1**2],
+                    [q0**6+1, q0**7+q1, q0**8+q1**2]])
 
     """
     return simple_dispatch(

--- a/numpoly/array_function/all.py
+++ b/numpoly/array_function/all.py
@@ -36,14 +36,14 @@ def all(a, axis=None, out=None, keepdims=False, **kwargs):
             which case a reference to `out` is returned.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> numpoly.all(x)
+        >>> q0 = numpoly.variable()
+        >>> numpoly.all(q0)
         True
-        >>> numpoly.all(0*x)
+        >>> numpoly.all(0*q0)
         False
-        >>> numpoly.all([1, x, 0])
+        >>> numpoly.all([1, q0, 0])
         False
-        >>> numpoly.all([[True*x, False], [True, True]], axis=0)
+        >>> numpoly.all([[True*q0, False], [True, True]], axis=0)
         array([ True, False])
 
     """

--- a/numpoly/array_function/allclose.py
+++ b/numpoly/array_function/allclose.py
@@ -51,15 +51,15 @@ def allclose(a, b, rtol=1e-5, atol=1e-8, equal_nan=False):
         but not `array_equal`.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> numpoly.allclose([1e10*x, 1e-7], [1.00001e10*x, 1e-8])
+        >>> q0, q1 = numpoly.variable(2)
+        >>> numpoly.allclose([1e10*q0, 1e-7], [1.00001e10*q0, 1e-8])
         False
-        >>> numpoly.allclose([1e10*x, 1e-8], [1.00001e10*x, 1e-9])
+        >>> numpoly.allclose([1e10*q0, 1e-8], [1.00001e10*q0, 1e-9])
         True
-        >>> numpoly.allclose([1e10*x, 1e-8], [1.00001e10*y, 1e-9])
+        >>> numpoly.allclose([1e10*q0, 1e-8], [1.00001e10*q1, 1e-9])
         False
-        >>> numpoly.allclose([x, numpy.nan],
-        ...                  [x, numpy.nan], equal_nan=True)
+        >>> numpoly.allclose([q0, numpy.nan],
+        ...                  [q0, numpy.nan], equal_nan=True)
         True
 
     """

--- a/numpoly/array_function/amax.py
+++ b/numpoly/array_function/amax.py
@@ -43,15 +43,15 @@ def amax(a, axis=None, out=None, **kwargs):
             ``a.ndim-1``.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
+        >>> q0, q1 = numpoly.variable(2)
         >>> numpoly.amax([13, 7])
         polynomial(13)
-        >>> numpoly.amax([1, x, x**2, y])
-        polynomial(x**2)
-        >>> numpoly.amax([1, x, y])
-        polynomial(y)
-        >>> numpoly.amax([[3*x**2, 5*x**2], [2*x**2, 4*x**2]], axis=0)
-        polynomial([3*x**2, 5*x**2])
+        >>> numpoly.amax([1, q0, q0**2, q1])
+        polynomial(q0**2)
+        >>> numpoly.amax([1, q0, q1])
+        polynomial(q1)
+        >>> numpoly.amax([[3*q0**2, 5*q0**2], [2*q0**2, 4*q0**2]], axis=0)
+        polynomial([3*q0**2, 5*q0**2])
 
     """
     del out

--- a/numpoly/array_function/amin.py
+++ b/numpoly/array_function/amin.py
@@ -42,15 +42,15 @@ def amin(a, axis=None, out=None, **kwargs):
             ``a.ndim-1``.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
+        >>> q0, q1 = numpoly.variable(2)
         >>> numpoly.amin([13, 7])
         polynomial(7)
-        >>> numpoly.amin([1, x, x**2, y])
+        >>> numpoly.amin([1, q0, q0**2, q1])
         polynomial(1)
-        >>> numpoly.amin([x, y, x**2])
-        polynomial(x)
-        >>> numpoly.amin([[3*x**2, x**2], [2*x**2, 4*x**2]], axis=1)
-        polynomial([x**2, 2*x**2])
+        >>> numpoly.amin([q0, q1, q0**2])
+        polynomial(q0)
+        >>> numpoly.amin([[3*q0**2, q0**2], [2*q0**2, 4*q0**2]], axis=1)
+        polynomial([q0**2, 2*q0**2])
 
     """
     del out

--- a/numpoly/array_function/any.py
+++ b/numpoly/array_function/any.py
@@ -38,14 +38,14 @@ def any(a, axis=None, out=None, keepdims=False, **kwargs):
             in which case a reference to `out` is returned.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> numpoly.any(x)
+        >>> q0 = numpoly.variable()
+        >>> numpoly.any(q0)
         True
-        >>> numpoly.any(0*x)
+        >>> numpoly.any(0*q0)
         False
-        >>> numpoly.any([1, x, 0])
+        >>> numpoly.any([1, q0, 0])
         True
-        >>> numpoly.any([[True*x, False], [True, True]], axis=0)
+        >>> numpoly.any([[True*q0, False], [True, True]], axis=0)
         array([ True,  True])
 
     """

--- a/numpoly/array_function/apply_along_axis.py
+++ b/numpoly/array_function/apply_along_axis.py
@@ -54,12 +54,12 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
             fewer dimensions than `arr`.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> b = numpoly.polynomial([[1, 2, 3*x], [3, 6*y, 6], [2, 7, 9]])
+        >>> q0, q1 = numpoly.variable(2)
+        >>> b = numpoly.polynomial([[1, 2, 3*q0], [3, 6*q1, 6], [2, 7, 9]])
         >>> numpoly.apply_along_axis(numpoly.mean, 0, b)
-        polynomial([2.0, 2.0*y+3.0, x+5.0])
+        polynomial([2.0, 2.0*q1+3.0, q0+5.0])
         >>> numpoly.apply_along_axis(numpoly.mean, 1, b)
-        polynomial([x+1.0, 2.0*y+3.0, 6.0])
+        polynomial([q0+1.0, 2.0*q1+3.0, 6.0])
 
     """
     collection = list()
@@ -68,7 +68,8 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     def wrapper_func(array):
         """Wrap func1d function."""
         # Align indeterminants in case slicing changed them
-        array = numpoly.polynomial(array, names=arr.indeterminants)
+        array = numpoly.polynomial(
+            array, names=arr.indeterminants, allocation=arr.allocation)
         array, _ = numpoly.align.align_indeterminants(array, arr.indeterminants)
 
         # Evaluate function
@@ -102,5 +103,9 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     for idx, polynomial in enumerate(polynomials):
         ret_val[out == idx] = polynomial.values
 
-    return numpoly.aspolynomial(
-        ret_val, dtype=dtype, names=polynomials[0].indeterminants)
+    return numpoly.polynomial(
+        ret_val,
+        dtype=dtype,
+        names=polynomials[0].indeterminants,
+        allocation=polynomials[0].allocation,
+    )

--- a/numpoly/array_function/apply_over_axes.py
+++ b/numpoly/array_function/apply_over_axes.py
@@ -33,16 +33,16 @@ def apply_over_axes(func, a, axes):
             the shape of its output with respect to its input.
 
     Examples:
-        >>> polynomial = numpoly.symbols("x y z")*numpy.arange(24).reshape(2, 4, 3)
+        >>> polynomial = numpoly.variable(3)*numpy.arange(24).reshape(2, 4, 3)
         >>> numpoly.apply_over_axes(numpoly.sum, polynomial, 1)
-        polynomial([[[18*x, 22*y, 26*z]],
+        polynomial([[[18*q0, 22*q1, 26*q2]],
         <BLANKLINE>
-                    [[66*x, 70*y, 74*z]]])
+                    [[66*q0, 70*q1, 74*q2]]])
         >>> numpoly.apply_over_axes(numpoly.sum, polynomial, [0, 2])
-        polynomial([[[16*z+14*y+12*x],
-                     [22*z+20*y+18*x],
-                     [28*z+26*y+24*x],
-                     [34*z+32*y+30*x]]])
+        polynomial([[[16*q2+14*q1+12*q0],
+                     [22*q2+20*q1+18*q0],
+                     [28*q2+26*q1+24*q0],
+                     [34*q2+32*q1+30*q0]]])
 
     """
     @wraps(func)

--- a/numpoly/array_function/argmax.py
+++ b/numpoly/array_function/argmax.py
@@ -35,14 +35,14 @@ def argmax(a, axis=None, out=None, **kwargs):
         indices corresponding to the first occurrence are returned.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
+        >>> q0, q1 = numpoly.variable(2)
         >>> numpoly.argmax([13, 7])
         0
-        >>> numpoly.argmax([1, x, x**2, y])
+        >>> numpoly.argmax([1, q0, q0**2, q1])
         2
-        >>> numpoly.argmax([1, x, y])
+        >>> numpoly.argmax([1, q0, q1])
         2
-        >>> numpoly.argmax([[3*x**2, x**2], [2*x**2, 4*x**2]], axis=0)
+        >>> numpoly.argmax([[3*q0**2, q0**2], [2*q0**2, 4*q0**2]], axis=0)
         array([0, 1])
 
     """

--- a/numpoly/array_function/argmin.py
+++ b/numpoly/array_function/argmin.py
@@ -35,14 +35,14 @@ def argmin(a, axis=None, out=None, **kwargs):
         indices corresponding to the first occurrence are returned.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
+        >>> q0, q1 = numpoly.variable(2)
         >>> numpoly.argmin([13, 7])
         1
-        >>> numpoly.argmin([1, x, x**2, y])
+        >>> numpoly.argmin([1, q0, q0**2, q1])
         0
-        >>> numpoly.argmin([x*y, x, y])
+        >>> numpoly.argmin([q0*q1, q0, q1])
         1
-        >>> numpoly.argmin([[3*x**2, x**2], [2*x**2, 4*x**2]], axis=0)
+        >>> numpoly.argmin([[3*q0**2, q0**2], [2*q0**2, 4*q0**2]], axis=0)
         array([1, 0])
 
     """

--- a/numpoly/array_function/around.py
+++ b/numpoly/array_function/around.py
@@ -31,12 +31,12 @@ def around(a, decimals=0, out=None):
             a float.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> numpoly.around([0.37, 1.64*x-2.45])
-        polynomial([0.0, 2.0*x-2.0])
-        >>> numpoly.around([0.37, 1.64*x-23.45], decimals=1)
-        polynomial([0.4, 1.6*x-23.4])
-        >>> numpoly.around([0.37, 1.64*x-23.45], decimals=-1)
+        >>> q0 = numpoly.variable()
+        >>> numpoly.around([0.37, 1.64*q0-2.45])
+        polynomial([0.0, 2.0*q0-2.0])
+        >>> numpoly.around([0.37, 1.64*q0-23.45], decimals=1)
+        polynomial([0.4, 1.6*q0-23.4])
+        >>> numpoly.around([0.37, 1.64*q0-23.45], decimals=-1)
         polynomial([0.0, -20.0])
 
     """

--- a/numpoly/array_function/array_repr.py
+++ b/numpoly/array_function/array_repr.py
@@ -30,17 +30,17 @@ def array_repr(arr, max_line_width=None, precision=None, suppress_small=None):
             The string representation of an array.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> numpoly.array_repr(numpoly.polynomial([1, x]))
-        'polynomial([1, x])'
+        >>> q0 = numpoly.variable()
+        >>> numpoly.array_repr(numpoly.polynomial([1, q0]))
+        'polynomial([1, q0])'
         >>> numpoly.array_repr(numpoly.polynomial([]))
         'polynomial([], dtype=int64)'
         >>> numpoly.array_repr(
-        ...     numpoly.polynomial([1e-6, 4e-7*x, 2*x, 3]),
+        ...     numpoly.polynomial([1e-6, 4e-7*q0, 2*q0, 3]),
         ...     precision=4,
         ...     suppress_small=True,
         ... )
-        'polynomial([0.0, 0.0, 2.0*x, 3.0])'
+        'polynomial([0.0, 0.0, 2.0*q0, 3.0])'
 
     """
     prefix = "polynomial("
@@ -78,11 +78,11 @@ def to_string(poly, precision=None, suppress_small=None):
             If scalar, a string, or if array, numpy.array with string values.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> poly = numpoly.polynomial([[1, x**3], [y-1, -3*x]])
+        >>> q0, q1 = numpoly.variable(2)
+        >>> poly = numpoly.polynomial([[1, q0**3], [q1-1, -3*q0]])
         >>> string_array = to_string(poly)
         >>> string_array
-        [['1', 'x**3'], ['y-1', '-3*x']]
+        [['1', 'q0**3'], ['q1-1', '-3*q0']]
         >>> type(string_array[0][0]) == str
         True
 

--- a/numpoly/array_function/array_split.py
+++ b/numpoly/array_function/array_split.py
@@ -22,18 +22,18 @@ def array_split(ary, indices_or_sections, axis=0):
     Examples:
         >>> poly = numpoly.monomial(8).reshape(2, 4)
         >>> poly
-        polynomial([[1, q, q**2, q**3],
-                    [q**4, q**5, q**6, q**7]])
+        polynomial([[1, q0, q0**2, q0**3],
+                    [q0**4, q0**5, q0**6, q0**7]])
         >>> part1, part2, part3 = numpoly.array_split(poly, 3, axis=1)
         >>> part1
-        polynomial([[1, q],
-                    [q**4, q**5]])
+        polynomial([[1, q0],
+                    [q0**4, q0**5]])
         >>> part2
-        polynomial([[q**2],
-                    [q**6]])
+        polynomial([[q0**2],
+                    [q0**6]])
         >>> part3
-        polynomial([[q**3],
-                    [q**7]])
+        polynomial([[q0**3],
+                    [q0**7]])
 
     """
     ary = numpoly.aspolynomial(ary)

--- a/numpoly/array_function/array_str.py
+++ b/numpoly/array_function/array_str.py
@@ -35,17 +35,17 @@ def array_str(a, max_line_width=None, precision=None, suppress_small=None):
             The string representation of an array.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> numpoly.array_str(numpoly.polynomial([1, x]))
-        '[1 x]'
+        >>> q0 = numpoly.variable()
+        >>> numpoly.array_str(numpoly.polynomial([1, q0]))
+        '[1 q0]'
         >>> numpoly.array_str(numpoly.polynomial([]))
         '[]'
         >>> numpoly.array_str(
-        ...     numpoly.polynomial([1e-6, 4e-7*x, 2*x, 3]),
+        ...     numpoly.polynomial([1e-6, 4e-7*q0, 2*q0, 3]),
         ...     precision=4,
         ...     suppress_small=True,
         ... )
-        '[0.0 0.0 2.0*x 3.0]'
+        '[0.0 0.0 2.0*q0 3.0]'
 
     """
     a = numpoly.aspolynomial(a)

--- a/numpoly/array_function/atleast_1d.py
+++ b/numpoly/array_function/atleast_1d.py
@@ -23,8 +23,8 @@ def atleast_1d(*arys):
             made only if necessary.
 
     Examples:
-        >>> numpoly.atleast_1d(numpoly.symbols("x"))
-        polynomial([x])
+        >>> numpoly.atleast_1d(numpoly.variable())
+        polynomial([q0])
         >>> numpoly.atleast_1d(1, [2, 3])
         [polynomial([1]), polynomial([2, 3])]
 

--- a/numpoly/array_function/atleast_2d.py
+++ b/numpoly/array_function/atleast_2d.py
@@ -23,8 +23,8 @@ def atleast_2d(*arys):
             returned.
 
     Examples:
-        >>> numpoly.atleast_2d(numpoly.symbols("x"))
-        polynomial([[x]])
+        >>> numpoly.atleast_2d(numpoly.variable())
+        polynomial([[q0]])
         >>> numpoly.atleast_2d(1, [2, 3], [[4]])
         [polynomial([[1]]), polynomial([[2, 3]]), polynomial([[4]])]
 

--- a/numpoly/array_function/atleast_3d.py
+++ b/numpoly/array_function/atleast_3d.py
@@ -25,11 +25,14 @@ def atleast_3d(*arys):
             becomes a view of shape ``(M, N, 1)``.
 
     Examples:
-        >>> numpoly.atleast_3d(numpoly.symbols("x"))
-        polynomial([[[x]]])
-        >>> numpoly.atleast_3d(1, [2, 3])
-        [polynomial([[[1]]]), polynomial([[[2],
-                     [3]]])]
+        >>> numpoly.atleast_3d(numpoly.variable())
+        polynomial([[[q0]]])
+        >>> a, b = numpoly.atleast_3d(1, [2, 3])
+        >>> a
+        polynomial([[[1]]])
+        >>> b
+        polynomial([[[2],
+                     [3]]])
 
     """
     if len(arys) == 1:

--- a/numpoly/array_function/broadcast_arrays.py
+++ b/numpoly/array_function/broadcast_arrays.py
@@ -29,18 +29,18 @@ def broadcast_arrays(*args, **kwargs):
     Examples:
         >>> poly1 = numpoly.monomial(3).reshape(1, 3)
         >>> poly1
-        polynomial([[1, q, q**2]])
+        polynomial([[1, q0, q0**2]])
         >>> poly2 = numpoly.monomial(2).reshape(2, 1)
         >>> poly2
         polynomial([[1],
-                    [q]])
+                    [q0]])
         >>> result1, result2 = numpoly.broadcast_arrays(poly1, poly2)
         >>> result1
-        polynomial([[1, q, q**2],
-                    [1, q, q**2]])
+        polynomial([[1, q0, q0**2],
+                    [1, q0, q0**2]])
         >>> result2
         polynomial([[1, 1, 1],
-                    [q, q, q]])
+                    [q0, q0, q0]])
 
     """
     args = [numpoly.aspolynomial(arg) for arg in args]

--- a/numpoly/array_function/ceil.py
+++ b/numpoly/array_function/ceil.py
@@ -6,7 +6,7 @@ from ..dispatch import implements, simple_dispatch
 
 
 @implements(numpy.ceil)
-def ceil(x, out=None, where=True, **kwargs):
+def ceil(q0, out=None, where=True, **kwargs):
     r"""
     Return the ceiling of the input, element-wise.
 
@@ -38,14 +38,14 @@ def ceil(x, out=None, where=True, **kwargs):
             a scalar if `x` is a scalar.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> numpoly.ceil([-1.7*x, x-1.5, -0.2, 3.2+1.5*x, 1.7, 2.0])
-        polynomial([-x, x-1.0, 0.0, 2.0*x+4.0, 2.0, 2.0])
+        >>> q0 = numpoly.variable()
+        >>> numpoly.ceil([-1.7*q0, q0-1.5, -0.2, 3.2+1.5*q0, 1.7, 2.0])
+        polynomial([-q0, q0-1.0, 0.0, 2.0*q0+4.0, 2.0, 2.0])
 
     """
     return simple_dispatch(
         numpy_func=numpy.ceil,
-        inputs=(x,),
+        inputs=(q0,),
         out=out,
         where=where,
         **kwargs

--- a/numpoly/array_function/choose.py
+++ b/numpoly/array_function/choose.py
@@ -79,18 +79,18 @@ def choose(a, choices, out=None, mode="raise"):
         container should be either a list or a tuple.
 
     Examples:
-        >>> choices = numpoly.outer(numpoly.monomial(3, names="x"),
-        ...                         numpoly.monomial(3, names="y"))
+        >>> choices = numpoly.outer(numpoly.monomial(3, names="q0"),
+        ...                         numpoly.monomial(3, names="q1"))
         >>> choices
-        polynomial([[1, y, y**2],
-                    [x, x*y, x*y**2],
-                    [x**2, x**2*y, x**2*y**2]])
+        polynomial([[1, q1, q1**2],
+                    [q0, q0*q1, q0*q1**2],
+                    [q0**2, q0**2*q1, q0**2*q1**2]])
         >>> numpoly.choose([1, 2, 0], choices)
-        polynomial([x, x**2*y, y**2])
+        polynomial([q0, q0**2*q1, q1**2])
         >>> numpoly.choose([1, 3, 0], choices, mode="clip")
-        polynomial([x, x**2*y, y**2])
+        polynomial([q0, q0**2*q1, q1**2])
         >>> numpoly.choose([1, 3, 0], choices, mode="wrap")
-        polynomial([x, y, y**2])
+        polynomial([q0, q1, q1**2])
 
     """
     choices = numpoly.aspolynomial(choices)

--- a/numpoly/array_function/common_type.py
+++ b/numpoly/array_function/common_type.py
@@ -31,10 +31,10 @@ def common_type(*arrays):
         ...     numpy.array(2, dtype=numpy.float32)).__name__
         'float32'
         >>> numpoly.common_type(
-        ...     numpoly.symbols("x")).__name__
+        ...     numpoly.variable()).__name__
         'float64'
         >>> numpoly.common_type(
-        ...     numpy.arange(3), 1j*numpoly.symbols("x"), 45).__name__
+        ...     numpy.arange(3), 1j*numpoly.variable(), 45).__name__
         'complex128'
 
     """

--- a/numpoly/array_function/concatenate.py
+++ b/numpoly/array_function/concatenate.py
@@ -27,17 +27,17 @@ def concatenate(arrays, axis=0, out=None):
             The concatenated array.
 
     Examples:
-        >>> a = numpy.array([[1, 2], [3, 4]])
-        >>> b = numpoly.symbols("x y").reshape(1, 2)
-        >>> numpoly.concatenate((a, b), axis=0)
+        >>> const = numpy.array([[1, 2], [3, 4]])
+        >>> poly = numpoly.variable(2).reshape(1, 2)
+        >>> numpoly.concatenate((const, poly), axis=0)
         polynomial([[1, 2],
                     [3, 4],
-                    [x, y]])
-        >>> numpoly.concatenate((a, b.T), axis=1)
-        polynomial([[1, 2, x],
-                    [3, 4, y]])
-        >>> numpoly.concatenate((a, b), axis=None)
-        polynomial([1, 2, 3, 4, x, y])
+                    [q0, q1]])
+        >>> numpoly.concatenate((const, poly.T), axis=1)
+        polynomial([[1, 2, q0],
+                    [3, 4, q1]])
+        >>> numpoly.concatenate((const, poly), axis=None)
+        polynomial([1, 2, 3, 4, q0, q1])
 
     """
     arrays = numpoly.align_exponents(*arrays)

--- a/numpoly/array_function/count_nonzero.py
+++ b/numpoly/array_function/count_nonzero.py
@@ -5,7 +5,7 @@ import numpoly
 from ..dispatch import implements
 
 @implements(numpy.count_nonzero)
-def count_nonzero(x, axis=None, **kwargs):
+def count_nonzero(q0, axis=None, **kwargs):
     """
     Count the number of non-zero values in the array a.
 
@@ -24,17 +24,19 @@ def count_nonzero(x, axis=None, **kwargs):
             returned.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> numpoly.count_nonzero([x])
+        >>> q0, q1 = numpoly.variable(2)
+        >>> numpoly.count_nonzero([q0])
         1
-        >>> numpoly.count_nonzero([[0,x,x*x,0,0],[x+1,0,0,2*x,19*x]])
+        >>> numpoly.count_nonzero([[0, q0, q0*q0, 0, 0],
+        ...                        [q0+1, 0, 0, 2*q0, 19*q0]])
         5
-        >>> numpoly.count_nonzero([[0,x,7*x,0,0],[3*y,0,0,2,19*x+y]], axis=0)
+        >>> numpoly.count_nonzero([[0, q0, 7*q0, 0, 0],
+        ...                        [3*q1, 0, 0, 2, 19*q0+q1]], axis=0)
         array([1, 1, 1, 1, 1])
-        >>> numpoly.count_nonzero([[0,x,y,0,0],[x,0,0,2*x,19*y]], axis=1)
+        >>> numpoly.count_nonzero([[0, q0, q1, 0, 0],
+        ...                        [q0, 0, 0, 2*q0, 19*q1]], axis=1)
         array([2, 3])
 
     """
-    a = numpoly.aspolynomial(x)
-
+    a = numpoly.aspolynomial(q0)
     return numpy.count_nonzero(numpy.any(a.coefficients, axis=0), axis=axis)

--- a/numpoly/array_function/cumsum.py
+++ b/numpoly/array_function/cumsum.py
@@ -35,18 +35,18 @@ def cumsum(a, axis=None, dtype=None, out=None):
             `axis` is not None or `a` is a 1-d array.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> poly = numpoly.polynomial([[1, x, 3], [4, 5, y]])
+        >>> q0, q1 = numpoly.variable(2)
+        >>> poly = numpoly.polynomial([[1, q0, 3], [4, 5, q1]])
         >>> poly
-        polynomial([[1, x, 3],
-                    [4, 5, y]])
+        polynomial([[1, q0, 3],
+                    [4, 5, q1]])
         >>> numpoly.cumsum(poly)
-        polynomial([1, x+1, x+4, x+8, x+13, y+x+13])
+        polynomial([1, q0+1, q0+4, q0+8, q0+13, q1+q0+13])
         >>> numpoly.cumsum(poly, dtype=float)
-        polynomial([1.0, x+1.0, x+4.0, x+8.0, x+13.0, y+x+13.0])
+        polynomial([1.0, q0+1.0, q0+4.0, q0+8.0, q0+13.0, q1+q0+13.0])
         >>> numpoly.cumsum(poly, axis=0)
-        polynomial([[1, x, 3],
-                    [5, x+5, y+3]])
+        polynomial([[1, q0, 3],
+                    [5, q0+5, q1+3]])
 
     """
     return simple_dispatch(

--- a/numpoly/array_function/dsplit.py
+++ b/numpoly/array_function/dsplit.py
@@ -17,27 +17,30 @@ def dsplit(ary, indices_or_sections):
     Examples:
         >>> poly = numpoly.monomial(8).reshape(2, 2, 2)
         >>> poly
-        polynomial([[[1, q],
-                     [q**2, q**3]],
+        polynomial([[[1, q0],
+                     [q0**2, q0**3]],
         <BLANKLINE>
-                    [[q**4, q**5],
-                     [q**6, q**7]]])
+                    [[q0**4, q0**5],
+                     [q0**6, q0**7]]])
         >>> part1, part2 = numpoly.dsplit(poly, 2)
         >>> part1
         polynomial([[[1],
-                     [q**2]],
+                     [q0**2]],
         <BLANKLINE>
-                    [[q**4],
-                     [q**6]]])
+                    [[q0**4],
+                     [q0**6]]])
         >>> part2
-        polynomial([[[q],
-                     [q**3]],
+        polynomial([[[q0],
+                     [q0**3]],
         <BLANKLINE>
-                    [[q**5],
-                     [q**7]]])
+                    [[q0**5],
+                     [q0**7]]])
 
     """
     ary = numpoly.aspolynomial(ary)
     results = numpy.dsplit(ary.values, indices_or_sections=indices_or_sections)
-    return [numpoly.aspolynomial(result, names=ary.indeterminants)
-            for result in results]
+    return [
+        numpoly.polynomial(
+            result, names=ary.indeterminants, allocation=ary.allocation)
+        for result in results
+    ]

--- a/numpoly/array_function/dstack.py
+++ b/numpoly/array_function/dstack.py
@@ -31,20 +31,20 @@ def dstack(tup):
             3-D.
 
     Examples:
-        >>> a = numpoly.symbols("x y z")
-        >>> b = numpoly.polynomial([1, 2, 3])
-        >>> numpoly.dstack([a, b])
-        polynomial([[[x, 1],
-                     [y, 2],
-                     [z, 3]]])
-        >>> c = numpoly.polynomial([[1], [2], [3]])
-        >>> d = a.reshape(3, 1)
-        >>> numpoly.dstack([c, d])
-        polynomial([[[1, x]],
+        >>> poly1 = numpoly.variable(3)
+        >>> const1 = numpoly.polynomial([1, 2, 3])
+        >>> numpoly.dstack([poly1, const1])
+        polynomial([[[q0, 1],
+                     [q1, 2],
+                     [q2, 3]]])
+        >>> const2 = numpoly.polynomial([[1], [2], [3]])
+        >>> poly2 = poly1.reshape(3, 1)
+        >>> numpoly.dstack([const2, poly2])
+        polynomial([[[1, q0]],
         <BLANKLINE>
-                    [[2, y]],
+                    [[2, q1]],
         <BLANKLINE>
-                    [[3, z]]])
+                    [[3, q2]]])
 
     """
     arrays = numpoly.align_exponents(*tup)

--- a/numpoly/array_function/equal.py
+++ b/numpoly/array_function/equal.py
@@ -38,12 +38,12 @@ def equal(x1, x2, out=None, where=True, **kwargs):
             if both `x1` and `x2` are scalars.
 
     Examples:
-        >>> x, y, z = xyz = numpoly.symbols("x y z")
-        >>> numpoly.equal(xyz, x)
+        >>> q0, q1, q2 = q0q1q2 = numpoly.variable(3)
+        >>> numpoly.equal(q0q1q2, q0)
         array([ True, False, False])
-        >>> numpoly.equal(xyz, [y, y, z])
+        >>> numpoly.equal(q0q1q2, [q1, q1, q2])
         array([False,  True,  True])
-        >>> numpoly.equal(x, y)
+        >>> numpoly.equal(q0, q1)
         False
 
     """

--- a/numpoly/array_function/expand_dims.py
+++ b/numpoly/array_function/expand_dims.py
@@ -23,12 +23,12 @@ def expand_dims(a, axis):
             View of `a` with the number of dimensions increased by one.
 
     Examples:
-        >>> poly = numpoly.symbols("x y")
+        >>> poly = numpoly.variable(2)
         >>> numpoly.expand_dims(poly, axis=0)
-        polynomial([[x, y]])
+        polynomial([[q0, q1]])
         >>> numpoly.expand_dims(poly, axis=1)
-        polynomial([[x],
-                    [y]])
+        polynomial([[q0],
+                    [q1]])
 
     """
     a = numpoly.aspolynomial(a)

--- a/numpoly/array_function/floor.py
+++ b/numpoly/array_function/floor.py
@@ -6,7 +6,7 @@ from ..dispatch import implements, simple_dispatch
 
 
 @implements(numpy.floor)
-def floor(x, out=None, where=True, **kwargs):
+def floor(q0, out=None, where=True, **kwargs):
     r"""
     Return the floor of the input, element-wise.
 
@@ -38,14 +38,14 @@ def floor(x, out=None, where=True, **kwargs):
             a scalar.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> numpoly.floor([-1.7*x, x-1.5, -0.2, 3.2+1.5*x, 1.7, 2.0])
-        polynomial([-2.0*x, x-2.0, -1.0, x+3.0, 1.0, 2.0])
+        >>> q0 = numpoly.variable()
+        >>> numpoly.floor([-1.7*q0, q0-1.5, -0.2, 3.2+1.5*q0, 1.7, 2.0])
+        polynomial([-2.0*q0, q0-2.0, -1.0, q0+3.0, 1.0, 2.0])
 
     """
     return simple_dispatch(
         numpy_func=numpy.floor,
-        inputs=(x,),
+        inputs=(q0,),
         out=out,
         where=where,
         **kwargs

--- a/numpoly/array_function/floor_divide.py
+++ b/numpoly/array_function/floor_divide.py
@@ -55,11 +55,13 @@ def floor_divide(x1, x2, out=None, where=True, **kwargs):
     Examples:
         >>> numpoly.floor_divide([1, 3, 5], 2)
         polynomial([0, 1, 2])
-        >>> xyz = [1, 2, 4]*numpoly.symbols("x y z")
-        >>> numpoly.floor_divide(xyz, 2.)
-        polynomial([0.0, y, 2.0*z])
-        >>> numpoly.floor_divide(xyz, [1, 2, 4])
-        polynomial([x, y, z])
+        >>> poly = [1, 2, 4]*numpoly.variable(3)
+        >>> poly
+        polynomial([q0, 2*q1, 4*q2])
+        >>> numpoly.floor_divide(poly, 2.)
+        polynomial([0.0, q1, 2.0*q2])
+        >>> numpoly.floor_divide(poly, [1, 2, 4])
+        polynomial([q0, q1, q2])
 
     """
     x1, x2 = numpoly.align_polynomials(x1, x2)

--- a/numpoly/array_function/greater.py
+++ b/numpoly/array_function/greater.py
@@ -38,20 +38,20 @@ def greater(x1, x2, out=None, **kwargs):
             if both `x1` and `x2` are scalars.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
+        >>> q0, q1 = numpoly.variable(2)
         >>> numpoly.greater(3, 4)
         False
-        >>> numpoly.greater(4*x, 3*x)
+        >>> numpoly.greater(4*q0, 3*q0)
         True
-        >>> numpoly.greater(x, y)
+        >>> numpoly.greater(q0, q1)
         False
-        >>> numpoly.greater(x**2, x)
+        >>> numpoly.greater(q0**2, q0)
         True
-        >>> numpoly.greater([1, x, x**2, x**3], y)
+        >>> numpoly.greater([1, q0, q0**2, q0**3], q1)
         array([False, False,  True,  True])
-        >>> numpoly.greater(x+1, x-1)
+        >>> numpoly.greater(q0+1, q0-1)
         True
-        >>> numpoly.greater(x, x)
+        >>> numpoly.greater(q0, q0)
         False
 
     """

--- a/numpoly/array_function/greater_equal.py
+++ b/numpoly/array_function/greater_equal.py
@@ -38,20 +38,20 @@ def greater_equal(x1, x2, out=None, **kwargs):
             if both `x1` and `x2` are scalars.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
+        >>> q0, q1 = numpoly.variable(2)
         >>> numpoly.greater_equal(3, 4)
         False
-        >>> numpoly.greater_equal(4*x, 3*x)
+        >>> numpoly.greater_equal(4*q0, 3*q0)
         True
-        >>> numpoly.greater_equal(x, y)
+        >>> numpoly.greater_equal(q0, q1)
         False
-        >>> numpoly.greater_equal(x**2, x)
+        >>> numpoly.greater_equal(q0**2, q0)
         True
-        >>> numpoly.greater_equal([1, x, x**2, x**3], y)
+        >>> numpoly.greater_equal([1, q0, q0**2, q0**3], q1)
         array([False, False,  True,  True])
-        >>> numpoly.greater_equal(x+1, x-1)
+        >>> numpoly.greater_equal(q0+1, q0-1)
         True
-        >>> numpoly.greater_equal(x, x)
+        >>> numpoly.greater_equal(q0, q0)
         True
 
     """

--- a/numpoly/array_function/hsplit.py
+++ b/numpoly/array_function/hsplit.py
@@ -20,25 +20,29 @@ def hsplit(ary, indices_or_sections):
     Examples:
         >>> poly = numpoly.monomial(8).reshape(2, 4)
         >>> poly
-        polynomial([[1, q, q**2, q**3],
-                    [q**4, q**5, q**6, q**7]])
+        polynomial([[1, q0, q0**2, q0**3],
+                    [q0**4, q0**5, q0**6, q0**7]])
         >>> part1, part2 = numpoly.hsplit(poly, 2)
         >>> part1
-        polynomial([[1, q],
-                    [q**4, q**5]])
+        polynomial([[1, q0],
+                    [q0**4, q0**5]])
         >>> part2
-        polynomial([[q**2, q**3],
-                    [q**6, q**7]])
+        polynomial([[q0**2, q0**3],
+                    [q0**6, q0**7]])
         >>> part1, part2, part3 = numpoly.hsplit(poly, [1, 2])
         >>> part1
         polynomial([[1],
-                    [q**4]])
+                    [q0**4]])
         >>> part3
-        polynomial([[q**2, q**3],
-                    [q**6, q**7]])
+        polynomial([[q0**2, q0**3],
+                    [q0**6, q0**7]])
 
     """
     ary = numpoly.aspolynomial(ary)
     results = numpy.hsplit(ary.values, indices_or_sections=indices_or_sections)
-    return [numpoly.aspolynomial(result, names=ary.indeterminants)
-            for result in results]
+    return [
+        numpoly.polynomial(
+            result, names=ary.indeterminants, allocation=ary.allocation,
+        )
+        for result in results
+    ]

--- a/numpoly/array_function/hstack.py
+++ b/numpoly/array_function/hstack.py
@@ -29,16 +29,16 @@ def hstack(tup):
             The array formed by stacking the given arrays.
 
     Examples:
-        >>> a = numpoly.symbols("x y z")
-        >>> b = numpoly.polynomial([1, 2, 3])
-        >>> numpoly.hstack([a, b])
-        polynomial([x, y, z, 1, 2, 3])
-        >>> c = numpoly.polynomial([[1], [2], [3]])
-        >>> d = a.reshape(3, 1)
-        >>> numpoly.hstack([c, d])
-        polynomial([[1, x],
-                    [2, y],
-                    [3, z]])
+        >>> poly1 = numpoly.variable(3)
+        >>> const1 = numpoly.polynomial([1, 2, 3])
+        >>> numpoly.hstack([poly1, const1])
+        polynomial([q0, q1, q2, 1, 2, 3])
+        >>> const2 = numpoly.polynomial([[1], [2], [3]])
+        >>> poly2 = poly1.reshape(3, 1)
+        >>> numpoly.hstack([const2, poly2])
+        polynomial([[1, q0],
+                    [2, q1],
+                    [3, q2]])
 
     """
     arrays = numpoly.align_exponents(*tup)

--- a/numpoly/array_function/isclose.py
+++ b/numpoly/array_function/isclose.py
@@ -52,15 +52,15 @@ def isclose(a, b, rtol=1e-5, atol=1e-8, equal_nan=False):
         value for `atol` will result in `False` if either `a` or `b` is zero.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> numpoly.isclose([1e10*x, 1e-7], [1.00001e10*x, 1e-8])
+        >>> q0, q1 = numpoly.variable(2)
+        >>> numpoly.isclose([1e10*q0, 1e-7], [1.00001e10*q0, 1e-8])
         array([ True, False])
-        >>> numpoly.isclose([1e10*x, 1e-8], [1.00001e10*x, 1e-9])
+        >>> numpoly.isclose([1e10*q0, 1e-8], [1.00001e10*q0, 1e-9])
         array([ True,  True])
-        >>> numpoly.isclose([1e10*x, 1e-8], [1.00001e10*y, 1e-9])
+        >>> numpoly.isclose([1e10*q0, 1e-8], [1.00001e10*q1, 1e-9])
         array([False,  True])
-        >>> numpoly.isclose([x, numpy.nan],
-        ...                 [x, numpy.nan], equal_nan=True)
+        >>> numpoly.isclose([q0, numpy.nan],
+        ...                 [q0, numpy.nan], equal_nan=True)
         array([ True,  True])
 
     """

--- a/numpoly/array_function/isfinite.py
+++ b/numpoly/array_function/isfinite.py
@@ -6,7 +6,7 @@ from ..dispatch import implements, simple_dispatch
 
 
 @implements(numpy.isfinite)
-def isfinite(x, out=None, where=True, **kwargs):
+def isfinite(q0, out=None, where=True, **kwargs):
     """
     Test element-wise for finiteness (not infinity or not Not a Number).
 
@@ -45,7 +45,7 @@ def isfinite(x, out=None, where=True, **kwargs):
         True
         >>> numpoly.isfinite(0)
         True
-        >>> numpoly.isfinite(numpy.nan*numpoly.symbols("x"))
+        >>> numpoly.isfinite(numpy.nan*numpoly.variable())
         False
         >>> numpoly.isfinite(numpy.inf)
         False
@@ -57,7 +57,7 @@ def isfinite(x, out=None, where=True, **kwargs):
     """
     out = simple_dispatch(
         numpy_func=numpy.isfinite,
-        inputs=(x,),
+        inputs=(q0,),
         out=out,
         where=where,
         **kwargs

--- a/numpoly/array_function/less.py
+++ b/numpoly/array_function/less.py
@@ -38,20 +38,20 @@ def less(x1, x2, out=None, **kwargs):
             if both `x1` and `x2` are scalars.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
+        >>> q0, q1 = numpoly.variable(2)
         >>> numpoly.less(3, 4)
         True
-        >>> numpoly.less(4*x, 3*x)
+        >>> numpoly.less(4*q0, 3*q0)
         False
-        >>> numpoly.less(x, y)
+        >>> numpoly.less(q0, q1)
         True
-        >>> numpoly.less(x**2, x)
+        >>> numpoly.less(q0**2, q0)
         False
-        >>> numpoly.less([1, x, x**2, x**3], y)
+        >>> numpoly.less([1, q0, q0**2, q0**3], q1)
         array([ True,  True, False, False])
-        >>> numpoly.less(x+1, x-1)
+        >>> numpoly.less(q0+1, q0-1)
         False
-        >>> numpoly.less(x, x)
+        >>> numpoly.less(q0, q0)
         False
 
     """

--- a/numpoly/array_function/less_equal.py
+++ b/numpoly/array_function/less_equal.py
@@ -38,20 +38,20 @@ def less_equal(x1, x2, out=None, **kwargs):
             if both `x1` and `x2` are scalars.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
+        >>> q0, q1 = numpoly.variable(2)
         >>> numpoly.less_equal(3, 4)
         True
-        >>> numpoly.less_equal(4*x, 3*x)
+        >>> numpoly.less_equal(4*q0, 3*q0)
         False
-        >>> numpoly.less_equal(x, y)
+        >>> numpoly.less_equal(q0, q1)
         True
-        >>> numpoly.less_equal(x**2, x)
+        >>> numpoly.less_equal(q0**2, q0)
         False
-        >>> numpoly.less_equal([1, x, x**2, x**3], y)
+        >>> numpoly.less_equal([1, q0, q0**2, q0**3], q1)
         array([ True,  True, False, False])
-        >>> numpoly.less_equal(x+1, x-1)
+        >>> numpoly.less_equal(q0+1, q0-1)
         False
-        >>> numpoly.less_equal(x, x)
+        >>> numpoly.less_equal(q0, q0)
         True
 
     """

--- a/numpoly/array_function/logical_and.py
+++ b/numpoly/array_function/logical_and.py
@@ -38,13 +38,13 @@ def logical_and(x1, x2, out=None, where=True, **kwargs):
             a scalar if both `x1` and `x2` are scalars.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> numpoly.logical_and(x, 0)
+        >>> q0, q1 = numpoly.variable(2)
+        >>> numpoly.logical_and(q0, 0)
         False
-        >>> numpoly.logical_and([x, False], [x, y])
+        >>> numpoly.logical_and([q0, False], [q0, q1])
         array([ True, False])
-        >>> z = numpy.arange(5)
-        >>> numpoly.logical_and(z > 1, z < 4)
+        >>> const = numpy.arange(5)
+        >>> numpoly.logical_and(const > 1, const < 4)
         array([False, False,  True,  True, False])
 
     """

--- a/numpoly/array_function/matmul.py
+++ b/numpoly/array_function/matmul.py
@@ -35,7 +35,7 @@ def matmul(x1, x2, out=None, **kwargs):
             the second-to-last dimension of `x2`.
 
     Examples:
-        >>> poly = numpoly.symbols("q:4").reshape(2, 2)
+        >>> poly = numpoly.variable(4).reshape(2, 2)
         >>> poly
         polynomial([[q0, q1],
                     [q2, q3]])

--- a/numpoly/array_function/maximum.py
+++ b/numpoly/array_function/maximum.py
@@ -44,19 +44,19 @@ def maximum(x1, x2, out=None, **kwargs):
             both `x1` and `x2` are scalars.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
+        >>> q0, q1 = numpoly.variable(2)
         >>> numpoly.maximum(3, 4)
         polynomial(4)
-        >>> numpoly.maximum(4*x, 3*x)
-        polynomial(4*x)
-        >>> numpoly.maximum(x, y)
-        polynomial(y)
-        >>> numpoly.maximum(x**2, x)
-        polynomial(x**2)
-        >>> numpoly.maximum([1, x, x**2, x**3], y)
-        polynomial([y, y, x**2, x**3])
-        >>> numpoly.maximum(x+1, x-1)
-        polynomial(x+1)
+        >>> numpoly.maximum(4*q0, 3*q0)
+        polynomial(4*q0)
+        >>> numpoly.maximum(q0, q1)
+        polynomial(q1)
+        >>> numpoly.maximum(q0**2, q0)
+        polynomial(q0**2)
+        >>> numpoly.maximum([1, q0, q0**2, q0**3], q1)
+        polynomial([q1, q1, q0**2, q0**3])
+        >>> numpoly.maximum(q0+1, q0-1)
+        polynomial(q0+1)
 
     """
     x1, x2 = numpoly.align_polynomials(x1, x2)

--- a/numpoly/array_function/mean.py
+++ b/numpoly/array_function/mean.py
@@ -44,14 +44,14 @@ def mean(a, axis=None, dtype=None, out=None, **kwargs):
             otherwise a reference to the output array is returned.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> a = numpoly.polynomial([[1, 2*x], [3*y+x, 4]])
-        >>> numpoly.mean(a)
-        polynomial(0.75*y+0.75*x+1.25)
-        >>> numpoly.mean(a, axis=0)
-        polynomial([1.5*y+0.5*x+0.5, x+2.0])
-        >>> numpoly.mean(a, axis=1)
-        polynomial([x+0.5, 1.5*y+0.5*x+2.0])
+        >>> q0, q1 = numpoly.variable(2)
+        >>> poly = numpoly.polynomial([[1, 2*q0], [3*q1+q0, 4]])
+        >>> numpoly.mean(poly)
+        polynomial(0.75*q1+0.75*q0+1.25)
+        >>> numpoly.mean(poly, axis=0)
+        polynomial([1.5*q1+0.5*q0+0.5, q0+2.0])
+        >>> numpoly.mean(poly, axis=1)
+        polynomial([q0+0.5, 1.5*q1+0.5*q0+2.0])
 
     """
     return simple_dispatch(

--- a/numpoly/array_function/minimum.py
+++ b/numpoly/array_function/minimum.py
@@ -44,19 +44,19 @@ def minimum(x1, x2, out=None, **kwargs):
             both `x1` and `x2` are scalars.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
+        >>> q0, q1 = numpoly.variable(2)
         >>> numpoly.minimum(3, 4)
         polynomial(3)
-        >>> numpoly.minimum(4*x, 3*x)
-        polynomial(3*x)
-        >>> numpoly.minimum(x, y)
-        polynomial(x)
-        >>> numpoly.minimum(x**2, x)
-        polynomial(x)
-        >>> numpoly.minimum([1, x, x**2, x**3], y)
-        polynomial([1, x, y, y])
-        >>> numpoly.minimum(x+1, x-1)
-        polynomial(x-1)
+        >>> numpoly.minimum(4*q0, 3*q0)
+        polynomial(3*q0)
+        >>> numpoly.minimum(q0, q1)
+        polynomial(q0)
+        >>> numpoly.minimum(q0**2, q0)
+        polynomial(q0)
+        >>> numpoly.minimum([1, q0, q0**2, q0**3], q1)
+        polynomial([1, q0, q1, q1])
+        >>> numpoly.minimum(q0+1, q0-1)
+        polynomial(q0-1)
 
     """
     x1, x2 = numpoly.align_polynomials(x1, x2)

--- a/numpoly/array_function/moveaxis.py
+++ b/numpoly/array_function/moveaxis.py
@@ -26,10 +26,10 @@ def moveaxis(a, source, destination):
             Array with moved axes. This array is a view of the input array.
 
     Examples:
-        >>> x = numpy.arange(6).reshape(1, 2, 3)
-        >>> numpoly.moveaxis(x, 0, -1).shape
+        >>> poly = numpoly.monomial(6).reshape(1, 2, 3)
+        >>> numpoly.moveaxis(poly, 0, -1).shape
         (2, 3, 1)
-        >>> numpoly.moveaxis(x, [0, 2], [2, 0]).shape
+        >>> numpoly.moveaxis(poly, [0, 2], [2, 0]).shape
         (3, 2, 1)
 
     """

--- a/numpoly/array_function/multiply.py
+++ b/numpoly/array_function/multiply.py
@@ -37,12 +37,12 @@ def multiply(x1, x2, out=None, where=True, **kwargs):
             both `x1` and `x2` are scalars.
 
     Examples:
-        >>> x1 = numpy.arange(9.0).reshape((3, 3))
-        >>> xyz = numpoly.symbols("x y z")
-        >>> numpoly.multiply(x1, xyz)
-        polynomial([[0.0, y, 2.0*z],
-                    [3.0*x, 4.0*y, 5.0*z],
-                    [6.0*x, 7.0*y, 8.0*z]])
+        >>> poly = numpy.arange(9.0).reshape((3, 3))
+        >>> q0q1q2 = numpoly.variable(3)
+        >>> numpoly.multiply(poly, q0q1q2)
+        polynomial([[0.0, q1, 2.0*q2],
+                    [3.0*q0, 4.0*q1, 5.0*q2],
+                    [6.0*q0, 7.0*q1, 8.0*q2]])
 
     """
     x1, x2 = numpoly.align_polynomials(x1, x2)

--- a/numpoly/array_function/negative.py
+++ b/numpoly/array_function/negative.py
@@ -35,9 +35,9 @@ def negative(x, out=None, where=True, **kwargs):
             a scalar.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> numpoly.negative([-x, x])
-        polynomial([x, -x])
+        >>> q0 = numpoly.variable()
+        >>> numpoly.negative([-q0, q0])
+        polynomial([q0, -q0])
 
     """
     return simple_dispatch(

--- a/numpoly/array_function/nonzero.py
+++ b/numpoly/array_function/nonzero.py
@@ -4,6 +4,7 @@ import numpoly
 
 from ..dispatch import implements
 
+
 @implements(numpy.nonzero)
 def nonzero(x, **kwargs):
     """
@@ -18,18 +19,19 @@ def nonzero(x, **kwargs):
             Indices of elements that are non-zero.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> f = numpoly.polynomial([[3*x, 0, 0], [0, 4*y, 0], [5*x+y, 6*x, 0]])
-        >>> f
-        polynomial([[3*x, 0, 0],
-                    [0, 4*y, 0],
-                    [y+5*x, 6*x, 0]])
-        >>> numpoly.nonzero(f)
+        >>> q0, q1 = numpoly.variable(2)
+        >>> poly = numpoly.polynomial([[3*q0, 0, 0],
+        ...                            [0, 4*q1, 0],
+        ...                            [5*q0+q1, 6*q0, 0]])
+        >>> poly
+        polynomial([[3*q0, 0, 0],
+                    [0, 4*q1, 0],
+                    [q1+5*q0, 6*q0, 0]])
+        >>> numpoly.nonzero(poly)
         (array([0, 1, 2, 2]), array([0, 1, 0, 1]))
-        >>> f[numpoly.nonzero(f)]
-        polynomial([3*x, 4*y, y+5*x, 6*x])
+        >>> poly[numpoly.nonzero(poly)]
+        polynomial([3*q0, 4*q1, q1+5*q0, 6*q0])
 
     """
-    a = numpoly.aspolynomial(x)
-
-    return numpy.nonzero(numpy.any(a.coefficients, axis=0))
+    x = numpoly.aspolynomial(x)
+    return numpy.nonzero(numpy.any(x.coefficients, axis=0))

--- a/numpoly/array_function/not_equal.py
+++ b/numpoly/array_function/not_equal.py
@@ -37,10 +37,10 @@ def not_equal(x1, x2, out=None, where=True, **kwargs):
             of type bool, unless ``dtype=object`` is passed.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> numpoly.not_equal([x, x], [x, y])
+        >>> q0, q1 = numpoly.variable(2)
+        >>> numpoly.not_equal([q0, q0], [q0, q1])
         array([False,  True])
-        >>> numpoly.not_equal([x, x], [[x, y], [y, x]])
+        >>> numpoly.not_equal([q0, q0], [[q0, q1], [q1, q0]])
         array([[False,  True],
                [ True, False]])
 

--- a/numpoly/array_function/outer.py
+++ b/numpoly/array_function/outer.py
@@ -33,13 +33,15 @@ def outer(a, b, out=None):
             ``out[i, j] = a[i] * b[j]``
 
     Examples:
-        >>> numpoly.outer(numpoly.symbols("x y z"), numpy.arange(5))
-        polynomial([[0, x, 2*x, 3*x, 4*x],
-                    [0, y, 2*y, 3*y, 4*y],
-                    [0, z, 2*z, 3*z, 4*z]])
+        >>> poly = numpoly.variable(3)
+        >>> const = numpy.arange(5)
+        >>> numpoly.outer(poly, const)
+        polynomial([[0, q0, 2*q0, 3*q0, 4*q0],
+                    [0, q1, 2*q1, 3*q1, 4*q1],
+                    [0, q2, 2*q2, 3*q2, 4*q2]])
 
     """
     a, b = numpoly.align_exponents(a, b)
-    a = a.flatten()[:, numpy.newaxis]
-    b = b.flatten()[numpy.newaxis, :]
+    a = a.ravel()[:, numpy.newaxis]
+    b = b.ravel()[numpy.newaxis, :]
     return numpoly.multiply(a, b, out=out)

--- a/numpoly/array_function/positive.py
+++ b/numpoly/array_function/positive.py
@@ -5,7 +5,7 @@ from ..dispatch import implements, simple_dispatch
 
 
 @implements(numpy.positive)  # pylint: disable=no-member
-def positive(x, out=None, where=True, **kwargs):
+def positive(q0, out=None, where=True, **kwargs):
     """
     Numerical positive, element-wise.
 
@@ -34,14 +34,14 @@ def positive(x, out=None, where=True, **kwargs):
             a scalar.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> numpoly.positive([-0, 0, -x, x])
-        polynomial([0, 0, -x, x])
+        >>> q0 = numpoly.variable()
+        >>> numpoly.positive([-0, 0, -q0, q0])
+        polynomial([0, 0, -q0, q0])
 
     """
     return simple_dispatch(
         numpy_func=numpy.positive,  # pylint: disable=no-member
-        inputs=(x,),
+        inputs=(q0,),
         out=out,
         where=where,
         **kwargs

--- a/numpoly/array_function/power.py
+++ b/numpoly/array_function/power.py
@@ -43,12 +43,12 @@ def power(x1, x2, **kwargs):
             if both `x1` and `x2` are scalars.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> (x+1)**3
-        polynomial(x**3+3*x**2+3*x+1)
-        >>> poly = numpoly.symbols("x y")
-        >>> (poly+1)**[1, 2]
-        polynomial([x+1, y**2+2*y+1])
+        >>> q0 = numpoly.variable()
+        >>> (q0+1)**3
+        polynomial(q0**3+3*q0**2+3*q0+1)
+        >>> q0q1 = numpoly.variable(2)
+        >>> (q0q1+1)**[1, 2]
+        polynomial([q0+1, q1**2+2*q1+1])
 
     """
     x1 = numpoly.aspolynomial(x1)

--- a/numpoly/array_function/prod.py
+++ b/numpoly/array_function/prod.py
@@ -46,19 +46,19 @@ def prod(a, axis=None, dtype=None, out=None, keepdims=False, **kwargs):
             Returns a reference to `out` if specified.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> poly = numpoly.polynomial([[[1, x, x**2], [x+y, y, y]]])
+        >>> q0, q1 = numpoly.variable(2)
+        >>> poly = numpoly.polynomial([[[1, q0, q0**2], [q0+q1, q1, q1]]])
         >>> numpoly.prod(poly)
-        polynomial(x**3*y**3+x**4*y**2)
+        polynomial(q0**3*q1**3+q0**4*q1**2)
         >>> numpoly.prod(poly, keepdims=True)
-        polynomial([[[x**3*y**3+x**4*y**2]]])
+        polynomial([[[q0**3*q1**3+q0**4*q1**2]]])
         >>> numpoly.prod(poly, axis=1)
-        polynomial([[y+x, x*y, x**2*y]])
+        polynomial([[q1+q0, q0*q1, q0**2*q1]])
         >>> numpoly.prod(poly, axis=2, keepdims=True)
-        polynomial([[[x**3],
-                     [y**3+x*y**2]]])
+        polynomial([[[q0**3],
+                     [q1**3+q0*q1**2]]])
         >>> numpoly.prod(poly, axis=[1, 2])
-        polynomial([[[x**3*y**3+x**4*y**2]]])
+        polynomial([[[q0**3*q1**3+q0**4*q1**2]]])
 
     """
     a = numpoly.aspolynomial(a)

--- a/numpoly/array_function/repeat.py
+++ b/numpoly/array_function/repeat.py
@@ -26,22 +26,22 @@ def repeat(a, repeats, axis=0):
             given axis.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> numpoly.repeat(x, 4)
-        polynomial([x, x, x, x])
-        >>> poly = numpoly.polynomial([[1, x-1], [x**2, x]])
+        >>> q0 = numpoly.variable()
+        >>> numpoly.repeat(q0, 4)
+        polynomial([q0, q0, q0, q0])
+        >>> poly = numpoly.polynomial([[1, q0-1], [q0**2, q0]])
         >>> numpoly.repeat(poly, 2)
-        polynomial([[1, x-1],
-                    [1, x-1],
-                    [x**2, x],
-                    [x**2, x]])
+        polynomial([[1, q0-1],
+                    [1, q0-1],
+                    [q0**2, q0],
+                    [q0**2, q0]])
         >>> numpoly.repeat(poly, 3, axis=1)
-        polynomial([[1, 1, 1, x-1, x-1, x-1],
-                    [x**2, x**2, x**2, x, x, x]])
+        polynomial([[1, 1, 1, q0-1, q0-1, q0-1],
+                    [q0**2, q0**2, q0**2, q0, q0, q0]])
         >>> numpoly.repeat(poly, [1, 2], axis=0)
-        polynomial([[1, x-1],
-                    [x**2, x],
-                    [x**2, x]])
+        polynomial([[1, q0-1],
+                    [q0**2, q0],
+                    [q0**2, q0]])
 
     """
     a = numpoly.aspolynomial(a)

--- a/numpoly/array_function/reshape.py
+++ b/numpoly/array_function/reshape.py
@@ -42,9 +42,9 @@ def reshape(a, newshape, order="C"):
         polynomial([[1, 2],
                     [3, 4]])
         >>> numpoly.reshape(numpoly.monomial(6), (3, 2))
-        polynomial([[1, q],
-                    [q**2, q**3],
-                    [q**4, q**5]])
+        polynomial([[1, q0],
+                    [q0**2, q0**3],
+                    [q0**4, q0**5]])
 
     """
     poly = numpoly.aspolynomial(a)

--- a/numpoly/array_function/rint.py
+++ b/numpoly/array_function/rint.py
@@ -35,9 +35,9 @@ def rint(x, out=None, where=True, **kwargs):
             is a scalar.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> numpoly.rint([-1.7*x, x-1.5, -0.2, 3.2+1.5*x, 1.7, 2.0])
-        polynomial([-2.0*x, x-2.0, 0.0, 2.0*x+3.0, 2.0, 2.0])
+        >>> q0 = numpoly.variable()
+        >>> numpoly.rint([-1.7*q0, q0-1.5, -0.2, 3.2+1.5*q0, 1.7, 2.0])
+        polynomial([-2.0*q0, q0-2.0, 0.0, 2.0*q0+3.0, 2.0, 2.0])
 
     """
     return simple_dispatch(

--- a/numpoly/array_function/split.py
+++ b/numpoly/array_function/split.py
@@ -55,20 +55,20 @@ def split(ary, indices_or_sections, axis=0):
     Examples:
         >>> poly = numpoly.monomial(16).reshape(4, 4)
         >>> poly
-        polynomial([[1, q, q**2, q**3],
-                    [q**4, q**5, q**6, q**7],
-                    [q**8, q**9, q**10, q**11],
-                    [q**12, q**13, q**14, q**15]])
+        polynomial([[1, q0, q0**2, q0**3],
+                    [q0**4, q0**5, q0**6, q0**7],
+                    [q0**8, q0**9, q0**10, q0**11],
+                    [q0**12, q0**13, q0**14, q0**15]])
         >>> part1, _ = numpoly.split(poly, 2, axis=0)
         >>> part1
-        polynomial([[1, q, q**2, q**3],
-                    [q**4, q**5, q**6, q**7]])
+        polynomial([[1, q0, q0**2, q0**3],
+                    [q0**4, q0**5, q0**6, q0**7]])
         >>> part1, _ = numpoly.split(poly, 2, axis=1)
         >>> part1
-        polynomial([[1, q],
-                    [q**4, q**5],
-                    [q**8, q**9],
-                    [q**12, q**13]])
+        polynomial([[1, q0],
+                    [q0**4, q0**5],
+                    [q0**8, q0**9],
+                    [q0**12, q0**13]])
 
     """
     ary = numpoly.aspolynomial(ary)

--- a/numpoly/array_function/square.py
+++ b/numpoly/array_function/square.py
@@ -38,8 +38,11 @@ def square(x, out=None, where=True, **kwargs):
     Examples:
         >>> numpoly.square([-1j, 1])
         polynomial([(-1-0j), (1+0j)])
-        >>> numpoly.square(numpoly.sum(numpoly.symbols("x y")))
-        polynomial(y**2+2*x*y+x**2)
+        >>> poly = numpoly.sum(numpoly.variable(2))
+        >>> poly
+        polynomial(q1+q0)
+        >>> numpoly.square(poly)
+        polynomial(q1**2+2*q0*q1+q0**2)
 
     """
     return multiply(x, x, out=out, where=where, **kwargs)

--- a/numpoly/array_function/stack.py
+++ b/numpoly/array_function/stack.py
@@ -30,15 +30,15 @@ def stack(arrays, axis=0, out=None):
             The stacked array has one more dimension than the input arrays.
 
     Examples:
-        >>> a = numpoly.symbols("x y z")
-        >>> b = numpoly.polynomial([1, 2, 3])
-        >>> numpoly.stack([a, b])
-        polynomial([[x, y, z],
+        >>> poly = numpoly.variable(3)
+        >>> const = numpoly.polynomial([1, 2, 3])
+        >>> numpoly.stack([poly, const])
+        polynomial([[q0, q1, q2],
                     [1, 2, 3]])
-        >>> numpoly.stack([a, b], axis=-1)
-        polynomial([[x, 1],
-                    [y, 2],
-                    [z, 3]])
+        >>> numpoly.stack([poly, const], axis=-1)
+        polynomial([[q0, 1],
+                    [q1, 2],
+                    [q2, 3]])
 
     """
     arrays = numpoly.align_exponents(*arrays)

--- a/numpoly/array_function/subtract.py
+++ b/numpoly/array_function/subtract.py
@@ -37,15 +37,15 @@ def subtract(x1, x2, out=None, where=True, **kwargs):
             both `x1` and `x2` are scalars.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> numpoly.subtract(x, 4)
-        polynomial(x-4)
-        >>> poly1 = x**numpy.arange(9).reshape((3, 3))
-        >>> poly2 = y**numpy.arange(3)
+        >>> q0, q1 = numpoly.variable(2)
+        >>> numpoly.subtract(q0, 4)
+        polynomial(q0-4)
+        >>> poly1 = q0**numpy.arange(9).reshape((3, 3))
+        >>> poly2 = q1**numpy.arange(3)
         >>> numpoly.subtract(poly1, poly2)
-        polynomial([[0, -y+x, -y**2+x**2],
-                    [x**3-1, x**4-y, x**5-y**2],
-                    [x**6-1, x**7-y, x**8-y**2]])
+        polynomial([[0, -q1+q0, -q1**2+q0**2],
+                    [q0**3-1, q0**4-q1, q0**5-q1**2],
+                    [q0**6-1, q0**7-q1, q0**8-q1**2]])
 
     """
     return simple_dispatch(

--- a/numpoly/array_function/sum.py
+++ b/numpoly/array_function/sum.py
@@ -47,13 +47,12 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=False, **kwargs):
             returned.
 
     Examples:
-        >>> x, y, z = xyz = numpoly.symbols("x y z")
-        >>> numpoly.sum(xyz)
-        polynomial(z+y+x)
-        >>> numpoly.sum([[1, x], [y, z]])
-        polynomial(z+y+x+1)
-        >>> numpoly.sum([[1, x], [y, z]], axis=0)
-        polynomial([y+1, z+x])
+        >>> q0, q1, q2 = numpoly.variable(3)
+        >>> poly = numpoly.polynomial([[1, q0], [q1, q2]])
+        >>> numpoly.sum(poly)
+        polynomial(q2+q1+q0+1)
+        >>> numpoly.sum(poly, axis=0)
+        polynomial([q1+1, q2+q0])
 
     """
     return simple_dispatch(

--- a/numpoly/array_function/tile.py
+++ b/numpoly/array_function/tile.py
@@ -34,18 +34,18 @@ def tile(A, reps):
             The tiled output array.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> numpoly.tile(x, 4)
-        polynomial([x, x, x, x])
-        >>> poly = numpoly.polynomial([[1, x-1], [x**2, x]])
+        >>> q0 = numpoly.variable()
+        >>> numpoly.tile(q0, 4)
+        polynomial([q0, q0, q0, q0])
+        >>> poly = numpoly.polynomial([[1, q0-1], [q0**2, q0]])
         >>> numpoly.tile(poly, 2)
-        polynomial([[1, x-1, 1, x-1],
-                    [x**2, x, x**2, x]])
+        polynomial([[1, q0-1, 1, q0-1],
+                    [q0**2, q0, q0**2, q0]])
         >>> numpoly.tile(poly, [2, 1])
-        polynomial([[1, x-1],
-                    [x**2, x],
-                    [1, x-1],
-                    [x**2, x]])
+        polynomial([[1, q0-1],
+                    [q0**2, q0],
+                    [1, q0-1],
+                    [q0**2, q0]])
 
     """
     A = numpoly.aspolynomial(A)

--- a/numpoly/array_function/transpose.py
+++ b/numpoly/array_function/transpose.py
@@ -22,14 +22,14 @@ def transpose(a, axes=None):
             `a` with its axes permuted.  A view is returned whenever possible.
 
     Examples:
-        >>> poly = numpoly.monomial(3, names=("x", "y")).reshape(2, 3)
+        >>> poly = numpoly.monomial([3, 3]).reshape(2, 3)
         >>> poly
-        polynomial([[1, x, x**2],
-                    [y, x*y, y**2]])
+        polynomial([[1, q0, q0**2],
+                    [q1, q0*q1, q1**2]])
         >>> numpoly.transpose(poly)
-        polynomial([[1, y],
-                    [x, x*y],
-                    [x**2, y**2]])
+        polynomial([[1, q1],
+                    [q0, q0*q1],
+                    [q0**2, q1**2]])
 
     """
     a = numpoly.aspolynomial(a)

--- a/numpoly/array_function/true_divide.py
+++ b/numpoly/array_function/true_divide.py
@@ -55,11 +55,11 @@ def true_divide(x1, x2, out=None, where=True, **kwargs):
             division see ``numpoly.poly_divide``.
 
     Examples:
-        >>> xyz = numpoly.symbols("x y z")
-        >>> numpoly.true_divide(xyz, 4)
-        polynomial([0.25*x, 0.25*y, 0.25*z])
-        >>> numpoly.true_divide(xyz, [1, 2, 4])
-        polynomial([x, 0.5*y, 0.25*z])
+        >>> q0q1q2 = numpoly.variable(3)
+        >>> numpoly.true_divide(q0q1q2, 4)
+        polynomial([0.25*q0, 0.25*q1, 0.25*q2])
+        >>> numpoly.true_divide(q0q1q2, [1, 2, 4])
+        polynomial([q0, 0.5*q1, 0.25*q2])
 
     """
     x1, x2 = numpoly.align_polynomials(x1, x2)

--- a/numpoly/array_function/vsplit.py
+++ b/numpoly/array_function/vsplit.py
@@ -20,26 +20,29 @@ def vsplit(ary, indices_or_sections):
     Examples:
         >>> poly = numpoly.monomial(8).reshape(4, 2)
         >>> poly
-        polynomial([[1, q],
-                    [q**2, q**3],
-                    [q**4, q**5],
-                    [q**6, q**7]])
+        polynomial([[1, q0],
+                    [q0**2, q0**3],
+                    [q0**4, q0**5],
+                    [q0**6, q0**7]])
         >>> part1, part2 = numpoly.vsplit(poly, 2)
         >>> part1
-        polynomial([[1, q],
-                    [q**2, q**3]])
+        polynomial([[1, q0],
+                    [q0**2, q0**3]])
         >>> part2
-        polynomial([[q**4, q**5],
-                    [q**6, q**7]])
+        polynomial([[q0**4, q0**5],
+                    [q0**6, q0**7]])
         >>> part1, part2, part3 = numpoly.vsplit(poly, [1, 2])
         >>> part1
-        polynomial([[1, q]])
+        polynomial([[1, q0]])
         >>> part3
-        polynomial([[q**4, q**5],
-                    [q**6, q**7]])
+        polynomial([[q0**4, q0**5],
+                    [q0**6, q0**7]])
 
     """
     ary = numpoly.aspolynomial(ary)
     results = numpy.vsplit(ary.values, indices_or_sections=indices_or_sections)
-    return [numpoly.aspolynomial(result, names=ary.indeterminants)
-            for result in results]
+    return [
+        numpoly.polynomial(
+            result, names=ary.indeterminants, allocation=ary.allocation)
+        for result in results
+    ]

--- a/numpoly/array_function/vstack.py
+++ b/numpoly/array_function/vstack.py
@@ -30,20 +30,20 @@ def vstack(tup):
             2-D.
 
     Examples:
-        >>> a = numpoly.symbols("x y z")
-        >>> b = numpoly.polynomial([1, 2, 3])
-        >>> numpoly.vstack([a, b])
-        polynomial([[x, y, z],
+        >>> poly1 = numpoly.variable(3)
+        >>> const1 = numpoly.polynomial([1, 2, 3])
+        >>> numpoly.vstack([poly1, const1])
+        polynomial([[q0, q1, q2],
                     [1, 2, 3]])
-        >>> c = numpoly.polynomial([[1], [2], [3]])
-        >>> d = a.reshape(3, 1)
-        >>> numpoly.vstack([c, d])
+        >>> const2 = numpoly.polynomial([[1], [2], [3]])
+        >>> poly2 = poly1.reshape(3, 1)
+        >>> numpoly.vstack([const2, poly2])
         polynomial([[1],
                     [2],
                     [3],
-                    [x],
-                    [y],
-                    [z]])
+                    [q0],
+                    [q1],
+                    [q2]])
 
     """
     arrays = numpoly.align_exponents(*tup)

--- a/numpoly/array_function/where.py
+++ b/numpoly/array_function/where.py
@@ -30,13 +30,13 @@ def where(condition, *args):
             elements from `y` elsewhere.
 
     Examples:
-        >>> poly = numpoly.symbols("x")*numpy.arange(4)
+        >>> poly = numpoly.variable()*numpy.arange(4)
         >>> poly
-        polynomial([0, x, 2*x, 3*x])
+        polynomial([0, q0, 2*q0, 3*q0])
         >>> numpoly.where([1, 0, 1, 0], 7, 2*poly)
-        polynomial([7, 2*x, 7, 6*x])
+        polynomial([7, 2*q0, 7, 6*q0])
         >>> numpoly.where(poly, 2*poly, 4)
-        polynomial([4, 2*x, 4*x, 6*x])
+        polynomial([4, 2*q0, 4*q0, 6*q0])
         >>> numpoly.where(poly)
         (array([1, 2, 3]),)
 

--- a/numpoly/construct/__init__.py
+++ b/numpoly/construct/__init__.py
@@ -5,3 +5,4 @@ from .clean import clean_attributes
 from .from_attributes import polynomial_from_attributes
 from .monomial import monomial
 from .symbols import symbols
+from .variable import variable

--- a/numpoly/construct/aspolynomial.py
+++ b/numpoly/construct/aspolynomial.py
@@ -1,5 +1,6 @@
 """Convert the input to an polynomial array."""
 from six import string_types
+
 import numpy
 import numpoly
 
@@ -28,10 +29,10 @@ def aspolynomial(
             dtype.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> numpoly.polynomial(x) is x
+        >>> q0 = numpoly.variable()
+        >>> numpoly.polynomial(q0) is q0
         False
-        >>> numpoly.aspolynomial(x) is x
+        >>> numpoly.aspolynomial(q0) is q0
         True
 
     """

--- a/numpoly/construct/clean.py
+++ b/numpoly/construct/clean.py
@@ -24,16 +24,16 @@ def clean_attributes(poly):
         Same as `poly`, but with attributes cleaned up.
 
     Examples:
-        >>> x, _ = numpoly.align_polynomials(*numpoly.symbols("x y"))
-        >>> x.indeterminants
-        polynomial([x, y])
-        >>> x.exponents
+        >>> q0, _ = numpoly.align_polynomials(*numpoly.variable(2))
+        >>> q0.indeterminants
+        polynomial([q0, q1])
+        >>> q0.exponents
         array([[1, 0],
                [0, 1]], dtype=uint32)
-        >>> x = numpoly.clean_attributes(x)
-        >>> x.indeterminants
-        polynomial([x])
-        >>> x.exponents
+        >>> q0 = numpoly.clean_attributes(q0)
+        >>> q0.indeterminants
+        polynomial([q0])
+        >>> q0.exponents
         array([[1]], dtype=uint32)
 
     """

--- a/numpoly/construct/compose.py
+++ b/numpoly/construct/compose.py
@@ -8,6 +8,7 @@ from .clean import postprocess_attributes
 def compose_polynomial_array(
         arrays,
         dtype=None,
+        allocation=None,
 ):
     """
     Compose polynomial from array of arrays of polynomials.
@@ -19,6 +20,9 @@ def compose_polynomial_array(
             Input to be converted to a `numpoly.ndpoly` polynomial type.
         dtype (Optional[numpy.dtype]):
             Data type used for the polynomial coefficients.
+        allocation (Optional[int]):
+            The maximum number of polynomial exponents. If omitted, use
+            length of exponents for allocation.
 
     Return:
         (numpoly.ndpoly):
@@ -81,4 +85,5 @@ def compose_polynomial_array(
         exponents=exponents,
         coefficients=coefficients,
         names=names,
+        allocation=allocation,
     )

--- a/numpoly/construct/from_attributes.py
+++ b/numpoly/construct/from_attributes.py
@@ -1,4 +1,5 @@
 """Construct polynomial from polynomial attributes."""
+import numpy
 import numpoly
 
 from . import clean as clean_
@@ -9,6 +10,7 @@ def polynomial_from_attributes(
         coefficients,
         names,
         dtype=None,
+        allocation=None,
         clean=True,
 ):
     """
@@ -29,6 +31,9 @@ def polynomial_from_attributes(
         dtype (Optional[numpy.dtype]):
             The data type of the polynomial. If omitted, extract from
             `coefficients`.
+        allocation (Optional[int]):
+            The maximum number of polynomial exponents. If omitted, use
+            length of exponents for allocation.
         clean (bool):
             Clean up attributes, removing redundant indeterminant names and
             exponents.
@@ -41,15 +46,15 @@ def polynomial_from_attributes(
         >>> numpoly.ndpoly.from_attributes(
         ...     exponents=[(0,), (1,)],
         ...     coefficients=[[1, 0], [0, 1]],
-        ...     names=("x",),
+        ...     names="q4",
         ... )
-        polynomial([1, x])
+        polynomial([1, q4])
         >>> numpoly.ndpoly.from_attributes(
         ...     exponents=[(0, 0, 0), (1, 1, 2)],
         ...     coefficients=[4, -1],
-        ...     names=("x", "y", "z"),
+        ...     names=("q2", "q4", "q10"),
         ... )
-        polynomial(-x*y*z**2+4)
+        polynomial(-q2*q4*q10**2+4)
         >>> numpoly.ndpoly.from_attributes(
         ...     exponents=[(0,)],
         ...     coefficients=[0],
@@ -71,7 +76,8 @@ def polynomial_from_attributes(
         shape=shape,
         names=names,
         dtype=dtype,
+        allocation=allocation,
     )
-    for exponent, values in zip(poly.keys, coefficients):
-        poly[exponent] = values
+    for key, values in zip(poly.keys, coefficients):
+        poly.values[key] = values
     return poly

--- a/numpoly/construct/monomial.py
+++ b/numpoly/construct/monomial.py
@@ -23,16 +23,18 @@ def monomial(start, stop=None, cross_truncation=1.,
         cross_truncation (float):
             Use hyperbolic cross truncation scheme to reduce the number of
             terms in expansion.
-        names (None, numpoly.ndpoly, str, Tuple[str, ...])
+        names (None, numpoly.ndpoly, int, str, Tuple[str, ...])
             The indeterminants names used to create the monomials expansion.
+            If int provided, set the number of names to use.
         graded (bool):
             Graded sorting, meaning the indices are always sorted by the index
-            sum. E.g. ``x**2*y**2*z**2`` has an exponent sum of 6, and will
-            therefore be consider larger than both ``x**3*y*z``, ``x*y**2*z``
-            and ``x*y*z**2``, which all have exponent sum of 5.
+            sum. E.g. ``q0**2*q1**2*q2**2`` has an exponent sum of 6, and will
+            therefore be consider larger than both ``q0**3*q1*q2``,
+            ``q0*q1**2*q2`` and ``q0*q1*q2**2``, which all have exponent
+            sum of 5.
         reverse (bool):
-            Reverse lexicographical sorting meaning that ``x*y**3`` is
-            considered bigger than ``x**3*y``, instead of the opposite.
+            Reverse lexicographical sorting meaning that ``q0*q1**3`` is
+            considered bigger than ``q0**3*q1``, instead of the opposite.
         allocation (Optional[int]):
             The maximum number of polynomial exponents. If omitted, use
             length of exponents for allocation.
@@ -44,7 +46,7 @@ def monomial(start, stop=None, cross_truncation=1.,
     Examples:
         >>> numpoly.monomial(4)
         polynomial([1, q0, q0**2, q0**3])
-        >>> numpoly.monomial([4, 4], 5, graded=True, reverse=True)
+        >>> numpoly.monomial(4, 5, names=2, graded=True, reverse=True)
         polynomial([q1**4, q0*q1**3, q0**2*q1**2, q0**3*q1, q0**4])
         >>> numpoly.monomial(2, [3, 4], graded=True)
         polynomial([q0**2, q0*q1, q1**2, q1**3])
@@ -60,6 +62,8 @@ def monomial(start, stop=None, cross_truncation=1.,
     stop = numpy.array(stop, dtype=int)
     if isinstance(names, str):
         names = (names,)
+    elif isinstance(names, int):
+        names = numpoly.variable(names)
     dimensions = 1 if names is None else len(names)
     dimensions = max(start.size, stop.size, dimensions)
 

--- a/numpoly/construct/monomial.py
+++ b/numpoly/construct/monomial.py
@@ -6,7 +6,7 @@ import numpoly
 
 
 def monomial(start, stop=None, cross_truncation=1.,
-             names=None, graded=False, reverse=False):
+             names=None, graded=False, reverse=False, allocation=None):
     """
     Create an polynomial monomial expansion.
 
@@ -33,6 +33,9 @@ def monomial(start, stop=None, cross_truncation=1.,
         reverse (bool):
             Reverse lexicographical sorting meaning that ``x*y**3`` is
             considered bigger than ``x**3*y``, instead of the opposite.
+        allocation (Optional[int]):
+            The maximum number of polynomial exponents. If omitted, use
+            length of exponents for allocation.
 
     Returns:
         (numpoly.ndpoly):
@@ -40,15 +43,14 @@ def monomial(start, stop=None, cross_truncation=1.,
 
     Examples:
         >>> numpoly.monomial(4)
-        polynomial([1, q, q**2, q**3])
-        >>> numpoly.monomial(4, 5, names=("x", "y"),
-        ...                  graded=True, reverse=True)
-        polynomial([y**4, x*y**3, x**2*y**2, x**3*y, x**4])
+        polynomial([1, q0, q0**2, q0**3])
+        >>> numpoly.monomial([4, 4], 5, graded=True, reverse=True)
+        polynomial([q1**4, q0*q1**3, q0**2*q1**2, q0**3*q1, q0**4])
         >>> numpoly.monomial(2, [3, 4], graded=True)
         polynomial([q0**2, q0*q1, q1**2, q1**3])
-        >>> numpoly.monomial(0, 5, names=("x", "y"),
+        >>> numpoly.monomial(0, 4, names=("q2", "q4"),
         ...                  cross_truncation=0.5, graded=True, reverse=True)
-        polynomial([1, y, x, y**2, x*y, x**2, y**3, x**3, y**4, x**4])
+        polynomial([1, q4, q2, q4**2, q2**2, q4**3, q2**3])
 
     """
     if stop is None:
@@ -56,6 +58,8 @@ def monomial(start, stop=None, cross_truncation=1.,
 
     start = numpy.array(start, dtype=int)
     stop = numpy.array(stop, dtype=int)
+    if isinstance(names, str):
+        names = (names,)
     dimensions = 1 if names is None else len(names)
     dimensions = max(start.size, stop.size, dimensions)
 
@@ -67,13 +71,13 @@ def monomial(start, stop=None, cross_truncation=1.,
         reverse=reverse,
         cross_truncation=cross_truncation,
     )
-
     poly = numpoly.ndpoly(
         exponents=indices,
         shape=(len(indices),),
         names=names,
+        allocation=allocation,
     )
     for coeff, key in zip(
             numpy.eye(len(indices), dtype=int), poly.keys):
-        poly[key] = coeff
+        numpy.ndarray.__setitem__(poly, key, coeff)
     return poly

--- a/numpoly/construct/symbols.py
+++ b/numpoly/construct/symbols.py
@@ -7,7 +7,7 @@ import numpy
 import numpoly
 
 
-def symbols(names=None, asarray=False, dtype="i8"):
+def symbols(names=None, asarray=False, dtype="i8", allocation=None):
     """
     Construct symbol variables.
 
@@ -27,6 +27,9 @@ def symbols(names=None, asarray=False, dtype="i8"):
             variable.
         dtype (numpy.dtype):
             The data type of the polynomial coefficients.
+        allocation (Optional[int]):
+            The maximum number of polynomial exponents. If omitted, use
+            length of exponents for allocation.
 
     Returns:
         (numpoly.ndpoly):
@@ -34,29 +37,23 @@ def symbols(names=None, asarray=False, dtype="i8"):
 
     Examples:
         >>> numpoly.symbols()
-        polynomial(q)
-        >>> numpoly.symbols("z,")
-        polynomial([z])
-        >>> numpoly.symbols("z", asarray=True)
-        polynomial([z])
-        >>> numpoly.symbols(["alpha", "beta"])
-        polynomial([alpha, beta])
-        >>> numpoly.symbols("x y z")
-        polynomial([x, y, z])
-        >>> numpoly.symbols("a,b,c")
-        polynomial([a, b, c])
+        polynomial(q0)
+        >>> numpoly.symbols("q4")
+        polynomial(q4)
         >>> numpoly.symbols("q:7")
         polynomial([q0, q1, q2, q3, q4, q5, q6])
         >>> numpoly.symbols("q3:6")
         polynomial([q3, q4, q5])
-        >>> numpoly.symbols("za:f")
-        polynomial([za, zb, zc, zd, ze, zf])
 
     """
     if names is None:
         coefficients = numpy.ones((1, 1) if asarray else 1, dtype=dtype)
         return numpoly.ndpoly.from_attributes(
-            exponents=[(1,)], coefficients=coefficients)
+            exponents=[(1,)],
+            coefficients=coefficients,
+            dtype=dtype,
+            allocation=allocation,
+        )
 
     if not isinstance(names, string_types):
         names = list(names)
@@ -100,4 +97,5 @@ def symbols(names=None, asarray=False, dtype="i8"):
         exponents=exponents,
         coefficients=coefficients,
         names=names,
+        allocation=allocation,
     )

--- a/numpoly/construct/variable.py
+++ b/numpoly/construct/variable.py
@@ -4,7 +4,7 @@ import numpoly
 
 def variable(dimensions=1, asarray=False, dtype="i8", allocation=None):
     """
-    Simple constructor to create single variables to create polynomials.
+    Construct variables that can be used to construct polynomials.
 
     Args:
         dimensions (int):
@@ -25,12 +25,15 @@ def variable(dimensions=1, asarray=False, dtype="i8", allocation=None):
     Examples:
         >>> numpoly.variable()
         polynomial(q0)
-        >>> numpoly.variable(3)
-        polynomial([q0, q1, q2])
+        >>> q0, q1, q2 = numpoly.variable(3)
+        >>> q1+1
+        polynomial(q1+1)
+        >>> numpoly.polynomial([q2**3, q1+q2, 1])
+        polynomial([q2**3, q2+q1, 1])
 
     """
     return numpoly.symbols(
-        names="q:%d" % dimensions,
+        names="%s:%d" % (numpoly.get_options()["default_varname"], dimensions),
         asarray=asarray,
         dtype=dtype,
         allocation=allocation,

--- a/numpoly/construct/variable.py
+++ b/numpoly/construct/variable.py
@@ -1,0 +1,37 @@
+"""Simple constructor to create single variables to create polynomials."""
+import numpoly
+
+
+def variable(dimensions=1, asarray=False, dtype="i8", allocation=None):
+    """
+    Simple constructor to create single variables to create polynomials.
+
+    Args:
+        dimensions (int):
+            Number of dimensions in the array.
+        asarray (bool):
+            Enforce output as array even in the case where there is only one
+            variable.
+        dtype (numpy.dtype):
+            The data type of the polynomial coefficients.
+        allocation (Optional[int]):
+            The maximum number of polynomial exponents. If omitted, use
+            length of exponents for allocation.
+
+    Returns:
+        (chaospy.poly.polynomial):
+            Polynomial array with unit components in each dimension.
+
+    Examples:
+        >>> numpoly.variable()
+        polynomial(q0)
+        >>> numpoly.variable(3)
+        polynomial([q0, q1, q2])
+
+    """
+    return numpoly.symbols(
+        names="q:%d" % dimensions,
+        asarray=asarray,
+        dtype=dtype,
+        allocation=allocation,
+    )

--- a/numpoly/dispatch.py
+++ b/numpoly/dispatch.py
@@ -87,6 +87,10 @@ def simple_dispatch(
                 dtype=tmp.dtype,
             )
             out[key] = tmp
+
+        elif no_output:
+            out[key] = numpy_func(*[poly[key] for poly in inputs], **kwargs)
+
         else:
             tmp = numpy_func(
                 *[poly[key] for poly in inputs], out=out[key], **kwargs)

--- a/numpoly/option.py
+++ b/numpoly/option.py
@@ -3,8 +3,8 @@ from contextlib import contextmanager
 
 GLOBAL_OPTIONS_DEFAULTS = {
     "default_varname": "q",
-    "force_number_suffix": False,
-    "varname_filter": r"[\w_]",
+    "force_number_suffix": True,
+    "varname_filter": r"q\d+",
     "sort_graded": True,
     "sort_reverse": False,
     "display_graded": True,
@@ -83,7 +83,7 @@ def set_options(**kwargs):
     Examples:
         >>> numpoly.monomial([3, 3])
         polynomial([1, q0, q0**2, q1, q0*q1, q1**2])
-        >>> numpoly.set_options(default_varname="z")
+        >>> numpoly.set_options(default_varname="z", varname_filter=".+")
         >>> numpoly.monomial([3, 3])
         polynomial([1, z0, z0**2, z1, z0*z1, z1**2])
 

--- a/numpoly/poly_function/call.py
+++ b/numpoly/poly_function/call.py
@@ -25,29 +25,29 @@ def call(poly, *args, **kwargs):
             indeterminants, an array is returned instead of a polynomial.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> poly = numpoly.polynomial([[x, x-1], [y, y+x]])
+        >>> q0, q1 = numpoly.variable(2)
+        >>> poly = numpoly.polynomial([[q0, q0-1], [q1, q1+q0]])
         >>> poly()
-        polynomial([[x, x-1],
-                    [y, y+x]])
+        polynomial([[q0, q0-1],
+                    [q1, q1+q0]])
         >>> poly
-        polynomial([[x, x-1],
-                    [y, y+x]])
+        polynomial([[q0, q0-1],
+                    [q1, q1+q0]])
         >>> poly(1, 0)
         array([[1, 0],
                [0, 1]])
-        >>> poly(1, y=[0, 1, 2])
+        >>> poly(1, q1=[0, 1, 2])
         array([[[1, 1, 1],
                 [0, 0, 0]],
         <BLANKLINE>
                [[0, 1, 2],
                 [1, 2, 3]]])
-        >>> poly(y)
-        polynomial([[y, y-1],
-                    [y, 2*y]])
-        >>> poly(y=x-1, x=2*y)
-        polynomial([[2*y, 2*y-1],
-                    [x-1, 2*y+x-1]])
+        >>> poly(q1)
+        polynomial([[q1, q1-1],
+                    [q1, 2*q1]])
+        >>> poly(q1=q0-1, q0=2*q1)
+        polynomial([[2*q1, 2*q1-1],
+                    [q0-1, 2*q1+q0-1]])
 
     """
     logger = logging.getLogger(__name__)

--- a/numpoly/poly_function/decompose.py
+++ b/numpoly/poly_function/decompose.py
@@ -8,7 +8,7 @@ def decompose(poly):
     Decompose a polynomial to component form.
 
     In array missing values are padded with 0 to make decomposition compatible
-    with ``chaospy.sum(ouput, 0)``.
+    with ``chaospy.sum(output, 0)``.
 
     Args:
         poly (numpoly.ndpoly):
@@ -20,15 +20,15 @@ def decompose(poly):
             where ``M`` is the number of components in `poly`.
 
     Examples:
-        >>> x = numpoly.symbols()
-        >>> poly = numpoly.polynomial([x**2-1, 2])
+        >>> q0 = numpoly.variable()
+        >>> poly = numpoly.polynomial([q0**2-1, 2])
         >>> poly
-        polynomial([q**2-1, 2])
+        polynomial([q0**2-1, 2])
         >>> numpoly.decompose(poly)
         polynomial([[-1, 2],
-                    [q**2, 0]])
+                    [q0**2, 0]])
         >>> numpoly.sum(numpoly.decompose(poly), 0)
-        polynomial([q**2-1, 2])
+        polynomial([q0**2-1, 2])
 
     """
     return numpoly.concatenate([

--- a/numpoly/poly_function/derivative.py
+++ b/numpoly/poly_function/derivative.py
@@ -19,15 +19,15 @@ def diff(poly, *diffvars):
         Same as ``poly`` but differentiated with respect to ``diffvars``.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> poly = numpoly.polynomial([1, x, x*y**2+1])
+        >>> q0, q1 = numpoly.variable(2)
+        >>> poly = numpoly.polynomial([1, q0, q0*q1**2+1])
         >>> poly
-        polynomial([1, x, x*y**2+1])
-        >>> numpoly.diff(poly, "x")
-        polynomial([0, 1, y**2])
+        polynomial([1, q0, q0*q1**2+1])
+        >>> numpoly.diff(poly, "q0")
+        polynomial([0, 1, q1**2])
         >>> numpoly.diff(poly, 0, 1)
-        polynomial([0, 0, 2*y])
-        >>> numpoly.diff(poly, x, x, x)
+        polynomial([0, 0, 2*q1])
+        >>> numpoly.diff(poly, q0, q0, q0)
         polynomial([0, 0, 0])
 
     """
@@ -76,17 +76,17 @@ def gradient(poly):
         variable in ``poly.indeterminants``, filled with gradient values.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> poly = 5*x**5+4
+        >>> q0, q1 = numpoly.variable(2)
+        >>> poly = 5*q0**5+4
         >>> numpoly.gradient(poly)
-        polynomial([25*x**4])
-        >>> poly = 4*x**3+2*y**2+3
+        polynomial([25*q0**4])
+        >>> poly = 4*q0**3+2*q1**2+3
         >>> numpoly.gradient(poly)
-        polynomial([12*x**2, 4*y])
-        >>> poly = numpoly.polynomial([1, x**3, x*y**2+1])
+        polynomial([12*q0**2, 4*q1])
+        >>> poly = numpoly.polynomial([1, q0**3, q0*q1**2+1])
         >>> numpoly.gradient(poly)
-        polynomial([[0, 3*x**2, y**2],
-                    [0, 0, 2*x*y]])
+        polynomial([[0, 3*q0**2, q1**2],
+                    [0, 0, 2*q0*q1]])
 
     """
     poly = numpoly.aspolynomial(poly)
@@ -111,21 +111,21 @@ def hessian(poly):
         variable in ``poly.indeterminants``, filled with Hessian values.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> poly = 5*x**5+4
+        >>> q0, q1 = numpoly.variable(2)
+        >>> poly = 5*q0**5+4
         >>> numpoly.hessian(poly)
-        polynomial([[100*x**3]])
-        >>> poly = 4*x**3+2*y**2+3
+        polynomial([[100*q0**3]])
+        >>> poly = 4*q0**3+2*q1**2+3
         >>> numpoly.hessian(poly)
-        polynomial([[24*x, 0],
+        polynomial([[24*q0, 0],
                     [0, 4]])
-        >>> poly = numpoly.polynomial([1, x, x*y**2+1])
+        >>> poly = numpoly.polynomial([1, q0, q0*q1**2+1])
         >>> numpoly.hessian(poly)
         polynomial([[[0, 0, 0],
-                     [0, 0, 2*y]],
+                     [0, 0, 2*q1]],
         <BLANKLINE>
-                    [[0, 0, 2*y],
-                     [0, 0, 2*x]]])
+                    [[0, 0, 2*q1],
+                     [0, 0, 2*q0]]])
 
     """
     return gradient(gradient(poly))

--- a/numpoly/poly_function/divide/divide.py
+++ b/numpoly/poly_function/divide/divide.py
@@ -43,12 +43,12 @@ def poly_divide(x1, x2, out=None, where=True, **kwargs):
             This is a scalar if both `x1` and `x2` are scalars.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> poly = numpoly.polynomial([14, x**2-3])
+        >>> q0 = numpoly.variable()
+        >>> poly = numpoly.polynomial([14, q0**2-3])
         >>> numpoly.poly_divide(poly, 4)
-        polynomial([3.5, 0.25*x**2-0.75])
-        >>> numpoly.poly_divide(poly, x)
-        polynomial([0.0, x])
+        polynomial([3.5, 0.25*q0**2-0.75])
+        >>> numpoly.poly_divide(poly, q0)
+        polynomial([0.0, q0])
 
     """
     dividend, remainder = poly_divmod(x1, x2, out=out, where=where, **kwargs)

--- a/numpoly/poly_function/divide/divmod.py
+++ b/numpoly/poly_function/divide/divmod.py
@@ -50,17 +50,17 @@ def poly_divmod(dividend, divisor, out=(None, None), where=True, **kwargs):
             are scalars.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> denominator = [x*y**2+2*x**3*y**2, -2+x*y**2]
-        >>> numerator = -2+x*y**2
+        >>> q0, q1 = numpoly.variable(2)
+        >>> denominator = [q0*q1**2+2*q0**3*q1**2, -2+q0*q1**2]
+        >>> numerator = -2+q0*q1**2
         >>> floor, remainder = numpoly.poly_divmod(
         ...     denominator, numerator)
         >>> floor
-        polynomial([2.0*x**2+1.0, 1.0])
+        polynomial([2.0*q0**2+1.0, 1.0])
         >>> remainder
-        polynomial([4.0*x**2+2.0, 0.0])
+        polynomial([4.0*q0**2+2.0, 0.0])
         >>> floor*numerator+remainder
-        polynomial([2.0*x**3*y**2+x*y**2, x*y**2-2.0])
+        polynomial([2.0*q0**3*q1**2+q0*q1**2, q0*q1**2-2.0])
 
     """
     assert where is True, "changing 'where' is not supported."

--- a/numpoly/poly_function/divide/remainder.py
+++ b/numpoly/poly_function/divide/remainder.py
@@ -48,11 +48,11 @@ def poly_remainder(x1, x2, out=None, where=True, **kwargs):
         ``numpoly.poly_remainder(11, 2) == 0``.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> denominator = [x*y**2+2*x**3*y**2, -2+x*y**2]
-        >>> numerator = -2+x*y**2
+        >>> q0, q1 = numpoly.variable(2)
+        >>> denominator = [q0*q1**2+2*q0**3*q1**2, -2+q0*q1**2]
+        >>> numerator = -2+q0*q1**2
         >>> numpoly.poly_remainder(denominator, numerator)
-        polynomial([4.0*x**2+2.0, 0.0])
+        polynomial([4.0*q0**2+2.0, 0.0])
 
     """
     dividend, remainder = poly_divmod(x1, x2, out=out, where=where, **kwargs)

--- a/numpoly/poly_function/isconstant.py
+++ b/numpoly/poly_function/isconstant.py
@@ -16,8 +16,8 @@ def isconstant(poly):
             True if polynomial has no indeterminants.
 
     Examples:
-        >>> x = numpoly.symbols("x")
-        >>> numpoly.isconstant(numpoly.polynomial([x]))
+        >>> q0 = numpoly.variable()
+        >>> numpoly.isconstant(numpoly.polynomial([q0]))
         False
         >>> numpoly.isconstant(numpoly.polynomial([1]))
         True

--- a/numpoly/poly_function/largest_exponent.py
+++ b/numpoly/poly_function/largest_exponent.py
@@ -17,12 +17,12 @@ def largest_exponent(poly, graded=False, reverse=False):
             Polynomial to locate exponents on.
         graded (bool):
             Graded sorting, meaning the indices are always sorted by the index
-            sum. E.g. ``x**2*y**2*z**2`` has an exponent sum of 6, and will
-            therefore be consider larger than both ``x**3*y*z``, ``x*y**3*z``
-            and ``x*y*z**3``.
+            sum. E.g. ``q0**2*q1**2*q2**2`` has an exponent sum of 6, and will
+            therefore be consider larger than both ``q0**3*q1*q2``,
+            ``q0*q1**3*q2`` and ``q0*q1*z**3``.
         reverse (bool):
-            Reverses lexicographical sorting meaning that ``x*y**3`` is
-            considered bigger than ``x**3*y``, instead of the opposite.
+            Reverses lexicographical sorting meaning that ``q0*q1**3`` is
+            considered bigger than ``q0**3*q1``, instead of the opposite.
 
     Returns:
         (numpy.ndarray):
@@ -31,10 +31,10 @@ def largest_exponent(poly, graded=False, reverse=False):
             is used to indicate the exponent for the different indeterminants.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> numpoly.largest_exponent([1, x+1, x**2+x+1]).T
+        >>> q0, q1 = numpoly.variable(2)
+        >>> numpoly.largest_exponent([1, q0+1, q0**2+q0+1]).T
         array([[0, 1, 2]])
-        >>> numpoly.largest_exponent([1, x, y, x*y, x**3-1]).T
+        >>> numpoly.largest_exponent([1, q0, q1, q0*q1, q0**3-1]).T
         array([[0, 1, 0, 1, 3],
                [0, 0, 1, 1, 0]])
 

--- a/numpoly/poly_function/sortable_proxy.py
+++ b/numpoly/poly_function/sortable_proxy.py
@@ -17,12 +17,12 @@ def sortable_proxy(poly, graded=False, reverse=False):
             Polynomial to convert into something sortable.
         graded (bool):
             Graded sorting, meaning the indices are always sorted by the index
-            sum. E.g. ``x**2*y**2*z**2`` has an exponent sum of 6, and will
-            therefore be consider larger than both ``x**3*y*z``, ``x*y**3*z``
-            and ``x*y*z**3``.
+            sum. E.g. ``q0**2*q1**2*q2**2`` has an exponent sum of 6, and will
+            therefore be consider larger than both ``q0**3*q1*q2``,
+            ``q0*q1**3*q2`` and ``q0*q1*z**3``.
         reverse (bool):
-            Reverses lexicographical sorting meaning that ``x*y**3`` is
-            considered smaller than ``x**3*y``, instead of the opposite.
+            Reverses lexicographical sorting meaning that ``q0*q1**3`` is
+            considered bigger than ``q0**3*q1``, instead of the opposite.
 
     Returns:
         (numpy.ndarray):
@@ -30,8 +30,8 @@ def sortable_proxy(poly, graded=False, reverse=False):
             ``ordering``.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> poly = numpoly.polynomial([x**2, 2*x, 3*y, 4*x, 5])
+        >>> q0, q1 = numpoly.variable(2)
+        >>> poly = numpoly.polynomial([q0**2, 2*q0, 3*q1, 4*q0, 5])
         >>> numpoly.sortable_proxy(poly)
         array([3, 1, 4, 2, 0])
         >>> numpoly.sortable_proxy(poly, reverse=True)

--- a/numpoly/sympy_.py
+++ b/numpoly/sympy_.py
@@ -16,12 +16,12 @@ def to_sympy(poly):
             expression object values.
 
     Examples:
-        >>> x, y = numpoly.symbols("x y")
-        >>> poly = numpoly.polynomial([[1, x**3], [y-1, -3*x]])
+        >>> q0, q1 = numpoly.variable(2)
+        >>> poly = numpoly.polynomial([[1, q0**3], [q1-1, -3*q0]])
         >>> sympy_poly = to_sympy(poly)
         >>> sympy_poly
-        array([[1, x**3],
-               [y - 1, -3*x]], dtype=object)
+        array([[1, q0**3],
+               [q1 - 1, -3*q0]], dtype=object)
         >>> type(sympy_poly.item(-1))
         <class 'sympy.core.mul.Mul'>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,20 +4,23 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "numpoly"
-version = "0.3.0"
-authors = ["Jonathan Feinberg <jonathf@gmail.com>"]
-repository = "https://github.com/jonathf/numpoly"
+version = "1.0.0"
 description = "Polynomials as a numpy datatype"
+license = "MIT"
+authors = ["Jonathan Feinberg"]
+repository = "https://github.com/jonathf/numpoly"
+documentation = "https://numpoly.readthedocs.io"
 readme = "README.rst"
 classifiers = [
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Mathematics",
-        "License :: OSI Approved :: BSD License",
+        "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
 ]
 
 [tool.poetry.dependencies]
+python = "*"
 numpy = "^1.16"
 six = "*"
 

--- a/test/test_align.py
+++ b/test/test_align.py
@@ -3,7 +3,7 @@ from numpoly import polynomial
 import numpoly
 
 
-X, Y = numpoly.symbols("X Y")
+X, Y = numpoly.variable(2)
 
 
 def test_align_polynomials():

--- a/test/test_array_function.py
+++ b/test/test_array_function.py
@@ -5,7 +5,7 @@ import numpy
 from numpoly import polynomial
 import numpoly
 
-X, Y = numpoly.symbols("X Y")
+X, Y = numpoly.variable(2)
 
 
 def test_absolute(interface):
@@ -115,18 +115,19 @@ def test_around(interface):
 
 
 def test_array_repr(func_interface):
-    assert repr(4+6*X**2) == "polynomial(6*X**2+4)"
-    assert func_interface.array_repr(4+6*X**2) == "polynomial(6*X**2+4)"
+    assert repr(polynomial([])).startswith("polynomial([], dtype=")
+    assert repr(4+6*X**2) == "polynomial(6*q0**2+4)"
+    assert func_interface.array_repr(4+6*X**2) == "polynomial(6*q0**2+4)"
     assert (repr(polynomial([1., -5*X, 3-X**2])) ==
-            "polynomial([1.0, -5.0*X, -X**2+3.0])")
+            "polynomial([1.0, -5.0*q0, -q0**2+3.0])")
     assert (func_interface.array_repr(polynomial([1., -5*X, 3-X**2])) ==
-            "polynomial([1.0, -5.0*X, -X**2+3.0])")
+            "polynomial([1.0, -5.0*q0, -q0**2+3.0])")
     assert repr(polynomial([[[1, 2], [5, Y]]])) == """\
 polynomial([[[1, 2],
-             [5, Y]]])"""
+             [5, q1]]])"""
     assert func_interface.array_repr(polynomial([[[1, 2], [5, Y]]])) == """\
 polynomial([[[1, 2],
-             [5, Y]]])"""
+             [5, q1]]])"""
 
 
 def test_array_split(func_interface):
@@ -138,16 +139,17 @@ def test_array_split(func_interface):
 
 
 def test_array_str(func_interface):
-    assert str(4+6*X**2) == "6*X**2+4"
-    assert func_interface.array_str(4+6*X**2) == "6*X**2+4"
-    assert str(polynomial([1., -5*X, 3-X**2])) == "[1.0 -5.0*X -X**2+3.0]"
-    assert func_interface.array_str(polynomial([1., -5*X, 3-X**2])) == "[1.0 -5.0*X -X**2+3.0]"
+    assert str(polynomial([])).startswith("[]")
+    assert str(4+6*X**2) == "6*q0**2+4"
+    assert func_interface.array_str(4+6*X**2) == "6*q0**2+4"
+    assert str(polynomial([1., -5*X, 3-X**2])) == "[1.0 -5.0*q0 -q0**2+3.0]"
+    assert func_interface.array_str(polynomial([1., -5*X, 3-X**2])) == "[1.0 -5.0*q0 -q0**2+3.0]"
     assert str(polynomial([[[1, 2], [5, Y]]])) == """\
 [[[1 2]
-  [5 Y]]]"""
+  [5 q1]]]"""
     assert func_interface.array_str(polynomial([[[1, 2], [5, Y]]])) == """\
 [[[1 2]
-  [5 Y]]]"""
+  [5 q1]]]"""
 
 
 def test_atleast_1d(func_interface):
@@ -277,7 +279,7 @@ def test_floor_divide(interface):
     out = numpoly.ndpoly(
         exponents=poly.exponents,
         shape=(2, 2),
-        names=("X", "Y"),
+        names=("q0", "q1"),
         dtype=float,
     )
     numpoly.floor_divide(poly, 2, out=[out])

--- a/test/test_baseclass.py
+++ b/test/test_baseclass.py
@@ -3,7 +3,7 @@ import numpy
 from pytest import raises
 import numpoly
 
-X, Y = XY = numpoly.symbols("X Y")
+X, Y = XY = numpoly.variable(2)
 EMPTY = numpoly.polynomial([])
 
 

--- a/test/test_construct.py
+++ b/test/test_construct.py
@@ -2,11 +2,12 @@
 from pytest import raises
 import numpy
 
+import sympy
 import numpoly
 from numpoly.construct.clean import (
     postprocess_attributes, PolynomialConstructionError)
 
-X, Y = XY = numpoly.symbols("X Y")
+X, Y = XY = numpoly.variable(2)
 
 
 def test_postprocess_attributes():
@@ -30,11 +31,62 @@ def test_aspolynomial():
     assert poly == numpoly.aspolynomial(poly)
     assert poly == numpoly.aspolynomial(poly, names=XY)
     assert poly == numpoly.aspolynomial(poly.todict(), names=XY)
-    assert poly == numpoly.aspolynomial(poly, names=("X", "Y"))
-    assert numpy.all(numpoly.symbols("Z:2") == numpoly.aspolynomial(XY, names="Z"))
-    assert poly == numpoly.aspolynomial(poly.todict(), names=("X", "Y"))
-    assert poly != numpoly.aspolynomial(poly.todict(), names=("Y", "X"))
-    assert X == numpoly.aspolynomial(Y, names="X")
-    assert poly != numpoly.aspolynomial(poly.todict(), names="X")
+    assert poly == numpoly.aspolynomial(poly, names=("q0", "q1"))
+    with numpoly.global_options(
+            varname_filter=r"\w+", force_number_suffix=False):
+        assert numpy.all(
+            numpoly.symbols("Z:2") == numpoly.aspolynomial(XY, names="Z"))
+    assert poly == numpoly.aspolynomial(poly.todict(), names=("q0", "q1"))
+    assert poly != numpoly.aspolynomial(poly.todict(), names=("q1", "q0"))
+    assert X == numpoly.aspolynomial(Y, names="q0")
+    assert poly != numpoly.aspolynomial(poly.todict(), names="q0")
     assert isinstance(numpoly.aspolynomial([1, 2, 3]), numpoly.ndpoly)
     assert numpy.all(numpoly.aspolynomial([1, 2, 3]) == [1, 2, 3])
+
+
+def test_monomial():
+    assert not numpoly.monomial(0).size
+    assert numpoly.monomial(1) == 1
+    assert numpy.all(numpoly.monomial(2, names="q0") == [1, X])
+    assert numpoly.monomial(1, 2, names="q0") == X
+
+
+def test_polynomial():
+    assert numpoly.polynomial() == 0
+    assert numpoly.polynomial({(0,): 4}) == 4
+    assert numpoly.polynomial({(1,): 5}, names="q0") == 5*X
+    assert numpoly.polynomial(
+        {(0, 1): 2, (1, 0): 3}, names=("q0", "q1")) == 3*X+2*Y
+    with numpoly.global_options(varname_filter=r"\w+"):
+        assert numpy.all(numpoly.polynomial(
+            {(0, 1): [0, 1], (1, 0): [1, 0]}, names="Q"
+        ) == numpoly.symbols("Q0 Q1"))
+    assert numpoly.polynomial(X) == X
+    assert numpoly.polynomial(numpy.array((3,), dtype=[(";", int)])) == 3
+    assert numpoly.polynomial(5.5) == 5.5
+    assert numpoly.polynomial(sympy.symbols("q0")) == X
+    assert numpy.all(numpoly.polynomial([1, 2, 3]) == [1, 2, 3])
+    assert numpy.all(numpoly.polynomial([[1, 2], [3, 4]]) == [[1, 2], [3, 4]])
+    assert numpy.all(numpoly.polynomial(
+        numpy.array([[1, 2], [3, 4]])) == [[1, 2], [3, 4]])
+
+
+def test_symbols():
+    assert numpoly.symbols() == X
+    assert numpoly.symbols().shape == ()
+    assert numpoly.symbols("q0") == X
+    assert numpoly.symbols("q0").shape == ()
+    assert numpoly.symbols("q0,") == X
+    assert numpoly.symbols("q0,").shape == (1,)
+    assert numpoly.symbols("q0", asarray=True) == X
+    assert numpoly.symbols("q0", asarray=True).shape == (1,)
+
+    assert numpoly.symbols("q:1").names == ("q0",)
+    with numpoly.global_options(
+            varname_filter=r"q\d*", force_number_suffix=False):
+        assert numpoly.symbols("q").names == ("q",)
+        assert numpoly.symbols("q1").names == ("q1",)
+
+    with numpoly.global_options(force_number_suffix=True):
+        assert numpoly.symbols("q").names == ("q0",)
+        assert numpoly.symbols("q1").names == ("q1",)

--- a/test/test_construct.py
+++ b/test/test_construct.py
@@ -82,11 +82,4 @@ def test_symbols():
     assert numpoly.symbols("q0", asarray=True).shape == (1,)
 
     assert numpoly.symbols("q:1").names == ("q0",)
-    with numpoly.global_options(
-            varname_filter=r"q\d*", force_number_suffix=False):
-        assert numpoly.symbols("q").names == ("q",)
-        assert numpoly.symbols("q1").names == ("q1",)
-
-    with numpoly.global_options(force_number_suffix=True):
-        assert numpoly.symbols("q").names == ("q0",)
-        assert numpoly.symbols("q1").names == ("q1",)
+    assert numpoly.symbols("q1").names == ("q1",)

--- a/test/test_option.py
+++ b/test/test_option.py
@@ -5,14 +5,14 @@ import numpoly
 POLYNOMIAL_CONFIGURATIONS = [
     dict(zip(["display_graded", "display_inverse", "display_reverse", "expected_output"], args)
          ) for args in [
-             (False, False, False, "1+x+x**2+y+x*y+y**2"),
-             (False, True, False, "y**2+x*y+y+x**2+x+1"),
-             (False, False, True, "1+y+y**2+x+x*y+x**2"),
-             (False, True, True, "x**2+x*y+x+y**2+y+1"),
-             (True, False, False, "1+x+y+x**2+x*y+y**2"),
-             (True, True, False, "y**2+x*y+x**2+y+x+1"),
-             (True, False, True, "1+y+x+y**2+x*y+x**2"),
-             (True, True, True, "x**2+x*y+y**2+x+y+1"),
+             (False, False, False, "1+q0+q0**2+q1+q0*q1+q1**2"),
+             (False, True, False, "q1**2+q0*q1+q1+q0**2+q0+1"),
+             (False, False, True, "1+q1+q1**2+q0+q0*q1+q0**2"),
+             (False, True, True, "q0**2+q0*q1+q0+q1**2+q1+1"),
+             (True, False, False, "1+q0+q1+q0**2+q0*q1+q1**2"),
+             (True, True, False, "q1**2+q0*q1+q0**2+q1+q0+1"),
+             (True, False, True, "1+q1+q0+q1**2+q0*q1+q0**2"),
+             (True, True, True, "q0**2+q0*q1+q1**2+q0+q1+1"),
 ]]
 
 
@@ -23,6 +23,6 @@ def display_config(request):
 
 def test_display_order(display_config):
     expected_output = display_config.pop("expected_output")
-    polynomial = numpy.sum(numpoly.monomial(3, names=("x", "y")))
+    polynomial = numpy.sum(numpoly.monomial(3, names=("q0", "q1")))
     with numpoly.global_options(**display_config):
         assert str(polynomial) == expected_output

--- a/test/test_poly_function.py
+++ b/test/test_poly_function.py
@@ -5,7 +5,7 @@ import sympy
 import numpy
 import numpoly
 
-X, Y = numpoly.symbols("X Y")
+X, Y = numpoly.variable(2)
 POLY1 = numpoly.polynomial([[1, X, X-1, X**2],
                             [Y, Y-1, Y**2, 1],
                             [X-1, X**2, 1, X],
@@ -15,51 +15,33 @@ POLY1 = numpoly.polynomial([[1, X, X-1, X**2],
 def test_call():
     poly = X+Y
     with raises(TypeError):
-        poly(1, X=2)
+        poly(1, q0=2)
     with raises(TypeError):
-        poly(1, 2, Y=3)
+        poly(1, 2, q1=3)
     with raises(TypeError):
         poly(not_an_arg=45)
     poly = numpoly.polynomial([2, X-Y+1])
-    assert numpy.all(poly(X=Y) == [2, 1])
+    assert numpy.all(poly(q0=Y) == [2, 1])
 
 
 def test_ndpoly():
-    poly = numpoly.ndpoly(exponents=[(1,)], shape=(), names="X")
+    poly = numpoly.ndpoly(exponents=[(1,)], shape=(), names="q0")
     poly["<"] = 1
     assert poly == X
     poly = numpoly.ndpoly(exponents=[(1,)], shape=(), names=X)
     poly["<"] = 1
     assert poly == X
     poly = numpoly.ndpoly(
-        exponents=[(1, 0), (0, 1)], shape=(), names=("X" ,"Y"))
+        exponents=[(1, 0), (0, 1)], shape=(), names=("q0" ,"q1"))
     poly["<;"] = 2
     poly[";<"] = 3
     assert poly == 2*X+3*Y
-    poly = numpoly.ndpoly(
-        exponents=[(1, 0), (0, 1)], shape=(2,), names="Q")
-    poly["<;"] = [1, 0]
-    poly[";<"] = [0, 1]
-    assert numpy.all(poly == numpoly.symbols("Q0 Q1"))
-
-
-def test_polynomial():
-    assert numpoly.polynomial() == 0
-    assert numpoly.polynomial({(0,): 4}) == 4
-    assert numpoly.polynomial({(1,): 5}, names="X") == 5*X
-    assert numpoly.polynomial(
-        {(0, 1): 2, (1, 0): 3}, names=("X", "Y")) == 3*X+2*Y
-    assert numpy.all(numpoly.polynomial(
-        {(0, 1): [0, 1], (1, 0): [1, 0]}, names="Q"
-    ) == numpoly.symbols("Q0 Q1"))
-    assert numpoly.polynomial(X) == X
-    assert numpoly.polynomial(numpy.array((3,), dtype=[(";", int)])) == 3
-    assert numpoly.polynomial(5.5) == 5.5
-    assert numpoly.polynomial(sympy.symbols("X")) == X
-    assert numpy.all(numpoly.polynomial([1, 2, 3]) == [1, 2, 3])
-    assert numpy.all(numpoly.polynomial([[1, 2], [3, 4]]) == [[1, 2], [3, 4]])
-    assert numpy.all(numpoly.polynomial(
-        numpy.array([[1, 2], [3, 4]])) == [[1, 2], [3, 4]])
+    with numpoly.global_options(varname_filter=r"Q\d+"):
+        poly = numpoly.ndpoly(
+            exponents=[(1, 0), (0, 1)], shape=(2,), names="Q:2")
+        poly["<;"] = [1, 0]
+        poly[";<"] = [0, 1]
+        assert numpy.all(poly == numpoly.symbols("Q0 Q1"))
 
 
 def test_poly_divide():
@@ -110,13 +92,6 @@ def test_tonumpy():
     assert isinstance(numpoly.tonumpy(numpoly.polynomial([1, 2, 3])), numpy.ndarray)
     with raises(numpoly.FeatureNotSupported):
         numpoly.tonumpy(X)
-
-
-def test_monomial():
-    assert not numpoly.monomial(0).size
-    assert numpoly.monomial(1) == 1
-    assert numpy.all(numpoly.monomial(2, names="X") == [1, X])
-    assert numpoly.monomial(1, 2, names="X") == X
 
 
 def test_poly_remainder():
@@ -174,15 +149,3 @@ def test_largest_exponent():
                             [1, 2, 0, 1], [0, 0, 0, 0]])
     assert numpy.all(ys == [[0, 0, 0, 0], [1, 1, 2, 0],
                             [0, 0, 0, 0], [2, 0, 1, 1]])
-
-
-def test_symbols():
-    with numpoly.global_options(force_number_suffix=False):
-        assert numpoly.symbols("q").names == ("q",)
-        assert numpoly.symbols("q:1").names == ("q0",)
-        assert numpoly.symbols("q1").names == ("q1",)
-
-    with numpoly.global_options(force_number_suffix=True):
-        assert numpoly.symbols("q").names == ("q0",)
-        assert numpoly.symbols("q:1").names == ("q0",)
-        assert numpoly.symbols("q1").names == ("q1",)


### PR DESCRIPTION
Change default behavior to be more restrictive with the naming forcing variable names to "q\d+". This to be more aligned with the chaospy project.

Old behavior can be added back by adding a line to your code right after import:
```python
numpoly.set_options(varname_filter=r"[\w_]+", force_number_suffix=False)
```