### PR TITLE
Bugfix: Divide causing infinity-loop

### DIFF
--- a/numpoly/poly_function/divide/divide.py
+++ b/numpoly/poly_function/divide/divide.py
@@ -51,6 +51,6 @@ def poly_divide(x1, x2, out=None, where=True, **kwargs):
         polynomial([0.0, q0])
 
     """
-    dividend, remainder = poly_divmod(x1, x2, out=out, where=where, **kwargs)
+    dividend, _ = poly_divmod(x1, x2, out=out, where=where, **kwargs)
     return dividend
 

--- a/numpoly/poly_function/divide/divmod.py
+++ b/numpoly/poly_function/divide/divmod.py
@@ -77,11 +77,8 @@ def poly_divmod(dividend, divisor, out=(None, None), where=True, **kwargs):
         candidates = get_division_candidate(dividend, divisor)
         if candidates is None:
             break
-        idx1, idx2, include = candidates
+        idx1, idx2, include, candidate = candidates
 
-        # construct candidate
-        candidate = dividend.coefficients[idx1]/numpy.where(
-            include, divisor.coefficients[idx2], 1)
         exponent_diff = dividend.exponents[idx1]-divisor.exponents[idx2]
         candidate = candidate*numpoly.prod(divisor.indeterminants**exponent_diff, 0)
 
@@ -141,7 +138,16 @@ def get_division_candidate(x1, x2):
             if not numpy.any(include):
                 continue
 
-            return idx1, idx2, include
+            # construct candidate
+            candidate = x1.coefficients[idx1]/numpy.where(
+                include, x2.coefficients[idx2], 1)
+
+            # really big relative error makes division algorithm
+            # into a convergence strategy which needs a cutoff.
+            if numpy.all(numpy.abs(candidate) < 1e-30):
+                continue
+
+            return idx1, idx2, include, candidate
 
     # No valid candidate pair found; Assume we are done.
     return None

--- a/test/test_poly_function.py
+++ b/test/test_poly_function.py
@@ -65,6 +65,18 @@ def test_poly_divmod():
     assert numpoly.poly_divmod(Y, X+2) == (0, Y)
     assert numpoly.poly_divmod(X*Y, X+2) == (Y, -2*Y)
 
+    x1 = -1.715408531156317e+18
+    x2 = 3.097893826691672e+18
+    divided, remainder = numpoly.poly_divmod(x1, x2)
+    assert numpoly.allclose(x1, x2*divided)
+    assert remainder == 0
+
+    x1 = (24*3600)**2*398600.4415
+    x2 = 2.689498059130061e-63*X**2+4.351432444850692e-27*X+1760083471.506941
+    divided, remainder = numpoly.poly_divmod(x1, x2)
+    assert numpoly.allclose(x1, x2*divided+remainder)
+    assert numpy.allclose(remainder, x1)
+
     assert divmod(X+3, 2) == (0.5*X+1.5, 0)
     assert divmod(Y+3, 2) == (0.5*Y+1.5, 0)
     assert divmod(3, numpoly.polynomial(2)) == (1.5, 0)


### PR DESCRIPTION
The long-division algoirithm causes an infinity loop when large relative error in division-subtraction step is introduced. This occours for division of numbers with large exponents.

Solves #64.