### PR TITLE
Make truncation formula less sensitive to rounding

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Master Branch
 =============
 
+Version 1.1.4 (2021-05-18)
+==========================
+
+FIXED:
+  * truncate function affected by rounding error.
+
 Version 1.1.3 (2021-04-02)
 ==========================
 

--- a/numpoly/utils/cross_truncation.py
+++ b/numpoly/utils/cross_truncation.py
@@ -7,7 +7,7 @@ def cross_truncate(indices, bound, norm):
     Truncate of indices using L_p norm.
 
     .. math:
-        L_p(x) = \sum_i |x_i/b_i|^p ^{1/p} \leq 1
+        L_p(x) = (\sum_i |x_i/b_i|^p )^{1/p} \leq 1
 
     where :math:`b_i` are bounds that each :math:`x_i` should follow.
 
@@ -37,7 +37,9 @@ def cross_truncate(indices, bound, norm):
 
     """
     assert norm >= 0, "negative L_p norm not allowed"
-    bound = numpy.asfarray(bound).flatten()*numpy.ones(indices.shape[1])
+    indices = numpy.asarray(indices)
+    bound = numpy.asfarray(bound).ravel()*numpy.ones(indices.shape[1])
+    nudge_factor = 1e-12*indices.shape[1]
 
     if numpy.any(bound < 0):
         return numpy.zeros((len(indices),), dtype=bool)
@@ -49,13 +51,12 @@ def cross_truncate(indices, bound, norm):
         return out
 
     if norm == 0:
-        out = numpy.sum(indices > 0, axis=-1) <= 1
+        out = numpy.sum(indices > 0, axis=-1) <= 1+nudge_factor
         out[numpy.any(indices > bound, axis=-1)] = False
     elif norm == numpy.inf:
-        out = numpy.max(indices/bound, axis=-1) <= 1
+        out = numpy.max(indices/bound, axis=-1) <= 1+nudge_factor
     else:
-        out = numpy.sum((indices/bound)**norm, axis=-1)**(1./norm) <= 1
+        out = numpy.sum((indices/bound)**norm, axis=-1)**(1./norm) <= 1+nudge_factor
 
     assert numpy.all(out[numpy.all(indices == 0, axis=-1)])
-
     return out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "numpoly"
-version = "1.1.3"
+version = "1.1.4"
 description = "Polynomials as a numpy datatype"
 license = "BSD-2-Clause"
 authors = ["Jonathan Feinberg"]


### PR DESCRIPTION
The multivariate generalization of truncation formula `|x|_p <= b` is
done as: `(sum((x/b)^p))^(1/p) <= 1` to allow for non-scalar `b`.
However, for intuitive setups like `b=9, p=1, x=[5,1,1,1,1]` will
evaluate as False because of rounding errors.

To fix this, we add a nudge factor to the bound:
`(sum((x/b)^p))^(1/p) <= 1+nudge`
Small enough that the user will never notice, but big enough to catch
all rounding errors.
As this problem is likely to scale with the dimensionality, the nudge
factor should scale the same way.

Solves #80.