### PR TITLE
Multiplication speedup.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Master Branch
 =============
 
+Version 1.2.2 (2021-05-23)
+==========================
+
+FIXED:
+  * Removed redundant calculations from multiplications, drastically improving
+    computational cost in some cases.
+
 Version 1.2.1 (2021-05-23)
 ==========================
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -91,12 +91,12 @@ scalar coefficients:
     polynomial([q0, q1])
     >>> coeff = poly.coefficients
     >>> coeff
-    [-1, 4, 3]
+    [4, 3, -1]
     >>> expon = poly.exponents
     >>> expon
-    array([[0, 0],
-           [1, 0],
-           [0, 1]], dtype=uint32)
+    array([[1, 0],
+           [0, 1],
+           [0, 0]], dtype=uint32)
 
 Because these three properties uniquely define a polynomial array, they can
 also be used to reconstruct the original polynomial:
@@ -105,7 +105,7 @@ also be used to reconstruct the original polynomial:
 
     >>> terms = coeff*numpoly.prod(indet**expon, axis=-1)
     >>> terms
-    polynomial([-1, 4*q0, 3*q1])
+    polynomial([4*q0, 3*q1, -1])
     >>> poly = numpoly.sum(terms, axis=0)
     >>> poly
     polynomial(3*q1+4*q0-1)

--- a/numpoly/array_function/array_repr.py
+++ b/numpoly/array_function/array_repr.py
@@ -55,7 +55,7 @@ def array_repr(
     suffix = ")"
     arr = numpoly.aspolynomial(arr)
     if not arr.size:
-        return prefix + "[], dtype=%s" % arr.dtype.name + suffix
+        return f"{prefix}[], dtype={arr.dtype.name}{suffix}"
 
     arr = to_string(arr, precision=precision, suppress_small=suppress_small)
 

--- a/numpoly/array_function/copyto.py
+++ b/numpoly/array_function/copyto.py
@@ -62,11 +62,10 @@ def copyto(
             if src.isconstant():
                 return numpy.copyto(
                     dst, src.tonumpy(), casting=casting, where=where)
-            raise ValueError(
-                "Could not convert src %s to dst %s" % (src, dst))
+            raise ValueError(f"Could not convert src {src} to dst {dst}")
         if casting != "unsafe":
             raise ValueError(
-                "could not safely convert src %s to dst %s" % (src, dst))
+                f"could not safely convert src {src} to dst {dst}")
         logger.warning("Copying ndpoly input into ndarray")
         logger.warning("You might need to cast `numpoly.polynomial(dst)`.")
         logger.warning("Indeterminant names might be lost.")
@@ -79,7 +78,7 @@ def copyto(
 
     missing_keys = set(src.keys).difference(dst_keys)
     if missing_keys:
-        raise ValueError("memory layouts are incompatible: %s" % missing_keys)
+        raise ValueError(f"memory layouts are incompatible: {missing_keys}")
 
     for key in dst_keys:
         if key in src.keys:

--- a/numpoly/array_function/multiply.py
+++ b/numpoly/array_function/multiply.py
@@ -56,7 +56,6 @@ def multiply(
 
     """
     x1, x2 = numpoly.align_indeterminants(x1, x2)
-    x1, x2 = numpoly.align_polynomials(x1, x2)
     dtype = numpy.find_common_type([x1.dtype, x2.dtype], [])
     shape = numpy.broadcast_shapes(x1.shape, x2.shape)
 
@@ -75,7 +74,7 @@ def multiply(
     for expon1, coeff1 in zip(x1.exponents, x1.coefficients):
         for expon2, coeff2 in zip(x2.exponents, x2.coefficients):
             key = (expon1+expon2+x1.KEY_OFFSET).ravel()
-            key = key.view("U%d" % len(expon1)).item()
+            key = key.view(f"U{len(expon1)}").item()
             if key in seen:
                 out_.values[key] += numpy.multiply(
                     coeff1, coeff2, where=where, **kwargs)

--- a/numpoly/array_function/savez.py
+++ b/numpoly/array_function/savez.py
@@ -49,8 +49,8 @@ def savez(file: PathLike, *args: PolyLike, **kwargs: PolyLike) -> None:
 
     """
     for idx, arg in enumerate(args):
-        assert "arr_%d" % idx not in kwargs, "naming conflict"
-        kwargs["arr_%d" % idx] = arg
+        assert f"arr_{idx}" not in kwargs, "naming conflict"
+        kwargs[f"arr_{idx}"] = arg
 
     polynomials = {
         key: numpoly.aspolynomial(kwargs.pop(key))

--- a/numpoly/array_function/savez_compressed.py
+++ b/numpoly/array_function/savez_compressed.py
@@ -52,8 +52,8 @@ def savez_compressed(
 
     """
     for idx, arg in enumerate(args):
-        assert "arr_%d" % idx not in kwargs, "naming conflict"
-        kwargs["arr_%d" % idx] = arg
+        assert f"arr_{idx}" not in kwargs, "naming conflict"
+        kwargs[f"arr_{idx}"] = arg
 
     polynomials = {
         key: numpoly.aspolynomial(kwargs.pop(key))

--- a/numpoly/construct/variable.py
+++ b/numpoly/construct/variable.py
@@ -42,7 +42,7 @@ def variable(
 
     """
     return numpoly.symbols(
-        names="%s:%d" % (numpoly.get_options()["default_varname"], dimensions),
+        names=f"{numpoly.get_options()['default_varname']}:{dimensions:d}",
         asarray=asarray,
         dtype=dtype,
         allocation=allocation,

--- a/numpoly/option.py
+++ b/numpoly/option.py
@@ -104,7 +104,7 @@ def set_options(**kwargs: Any) -> None:
     """
     for key in kwargs:
         if key not in _NUMPOLY_OPTIONS:
-            raise KeyError("option '%s' not recognised." % key)
+            raise KeyError(f"option '{key}' not recognized.")
     _NUMPOLY_OPTIONS.update(**kwargs)
 
 

--- a/numpoly/poly_function/call.py
+++ b/numpoly/poly_function/call.py
@@ -69,13 +69,12 @@ def call(
         parameters.update(kwargs)
     for arg, name in zip(args, poly.names):
         if name in kwargs:
-            raise TypeError(
-                "multiple values for argument '%s'" % name)
+            raise TypeError(f"multiple values for argument '{name}'")
         if arg is not None:
             parameters[name] = arg
     extra_args = [key for key in parameters if key not in poly.names]
     if extra_args:
-        raise TypeError("unexpected keyword argument '%s'" % extra_args[0])
+        raise TypeError(f"unexpected keyword argument '{extra_args[0]}'")
 
     # There can only be one shape:
     ones = numpy.ones((), dtype=int)

--- a/numpoly/poly_function/set_dimensions.py
+++ b/numpoly/poly_function/set_dimensions.py
@@ -46,9 +46,8 @@ def set_dimensions(poly: PolyLike, dimensions: Optional[int] = None) -> ndpoly:
         names_ = list(poly.names)
         idx = 0
         while len(names_) < dimensions:
-            candidate = "%s%d" % (varname, idx)
-            if candidate not in names_:
-                names_.append(candidate)
+            if f"{varname}{idx}" not in names_:
+                names_.append(f"{varname}{idx}")
             idx += 1
 
         indices = numpy.lexsort([names_])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "numpoly"
-version = "1.2.1"
+version = "1.2.2"
 description = "Polynomials as a numpy datatype"
 license = "BSD-2-Clause"
 authors = ["Jonathan Feinberg"]


### PR DESCRIPTION
Removes redundant calculations by not aligning the exponents before calculations.
For symmetric calculations like `(x^2+x+1)*(x^2+x+1)` this makes no
difference, as they are symmetrical. But for something like:
`(x^2+x+1)*(y^2+y+1)` or `(x^2+x+1)*(0,1,2)` we get a `O(n^2) -> O(n)`
reduction in computational cost.