### PR TITLE
Optimize by doing fewer alignments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,18 @@
 Master Branch
 =============
 
+Version 1.2.3 (2021-05-26)
+==========================
+
+Reduce the number of alignments.
+
+ADDED:
+  * Reduce the number memory copies, increasing speed for large arrays.
+
 Version 1.2.2 (2021-05-23)
 ==========================
 
-FIXED:
+ADDED:
   * Removed redundant calculations from multiplications, drastically improving
     computational cost in some cases.
 

--- a/docs/reference/miscellaneous.rst
+++ b/docs/reference/miscellaneous.rst
@@ -9,7 +9,6 @@ Alignment
 .. autosummary::
    :toctree: ../api
 
-   align_dtype
    align_exponents
    align_indeterminants
    align_polynomials

--- a/numpoly/__init__.py
+++ b/numpoly/__init__.py
@@ -11,7 +11,6 @@ from .align import (
     align_exponents,
     align_indeterminants,
     align_shape,
-    align_dtype,
 )
 from .construct import (
     polynomial,

--- a/numpoly/align.py
+++ b/numpoly/align.py
@@ -198,12 +198,7 @@ def align_exponents(*polys: PolyLike) -> Tuple[ndpoly, ...]:
     if not all(polys_[0].names == poly.names for poly in polys_):
         polys_ = list(align_indeterminants(*polys_))
 
-    global_exponents = [tuple(exponent) for exponent in polys_[0].exponents]
-    for poly in polys_[1:]:
-        global_exponents.extend([tuple(exponent)
-                                 for exponent in poly.exponents
-                                 if tuple(exponent) not in global_exponents])
-    global_exponents = numpy.vstack([poly.exponents for poly in polys_]) 
+    global_exponents = numpy.vstack([poly.exponents for poly in polys_])
     global_exponents = numpy.unique(global_exponents, axis=0).tolist()
 
     for idx, poly in enumerate(polys_):

--- a/numpoly/align.py
+++ b/numpoly/align.py
@@ -35,7 +35,7 @@ def align_polynomials(*polys: PolyLike) -> Tuple[ndpoly, ...]:
         >>> q0
         polynomial([q0, q0])
         >>> q0.coefficients
-        [array([1., 1.]), array([0., 0.])]
+        [array([0., 0.]), array([1., 1.])]
         >>> q0.indeterminants
         polynomial([q0, q1])
 
@@ -80,18 +80,17 @@ def align_shape(*polys: PolyLike) -> Tuple[ndpoly, ...]:
 
     """
     # return tuple(numpoly.broadcast_arrays(*polys))
-    polys_ = tuple(numpoly.aspolynomial(poly) for poly in polys)
-    common = numpy.ones((), dtype=int)
-    for poly in polys_:
-        if poly.size:
-            common = numpy.ones(poly.coefficients[0].shape, dtype=int)*common
+    polys_ = [numpoly.aspolynomial(poly) for poly in polys]
+    common = numpy.ones(
+        numpy.broadcast_shapes(*[poly.shape for poly in polys_]), dtype=int)
 
-    polys_ = tuple(poly.from_attributes(
-        exponents=poly.exponents,
-        coefficients=tuple(coeff*common for coeff in poly.coefficients),
-        names=poly.indeterminants,
-    ) for poly in polys_)
-    assert numpy.all([common.shape == poly.shape for poly in polys_])
+    for idx, poly in enumerate(polys_):
+        if poly.shape != common.shape:
+            polys_[idx] = poly.from_attributes(
+                exponents=poly.exponents,
+                coefficients=tuple(coeff*common for coeff in poly.coefficients),
+                names=poly.indeterminants,
+            )
     return tuple(polys_)
 
 
@@ -134,6 +133,8 @@ def align_indeterminants(*polys: PolyLike) -> Tuple[ndpoly, ...]:
         return tuple(polys_)
 
     for idx, poly in enumerate(polys_):
+        if poly.names == common_names:
+            continue
         indices = numpy.array([
             common_names.index(name)
             for name in poly.names
@@ -150,7 +151,6 @@ def align_indeterminants(*polys: PolyLike) -> Tuple[ndpoly, ...]:
             retain_coefficients=True,
             retain_names=True,
         )
-    assert all([polys_[0].names == poly.names for poly in polys_])
     return tuple(polys_)
 
 
@@ -184,32 +184,32 @@ def align_exponents(*polys: PolyLike) -> Tuple[ndpoly, ...]:
         >>> poly2
         polynomial([q0**5, q1**3-1])
         >>> poly1.exponents
-        array([[1, 1],
-               [0, 0],
+        array([[0, 0],
                [0, 3],
+               [1, 1],
                [5, 0]], dtype=uint32)
         >>> poly2.exponents
-        array([[1, 1],
-               [0, 0],
+        array([[0, 0],
                [0, 3],
+               [1, 1],
                [5, 0]], dtype=uint32)
 
     """
     polys_ = [numpoly.aspolynomial(poly) for poly in polys]
-    if not all(
-            polys_[0].names == poly.names
-            for poly in polys_
-    ):
+    if not all(polys_[0].names == poly.names for poly in polys_):
         polys_ = list(align_indeterminants(*polys_))
 
     global_exponents = [tuple(exponent) for exponent in polys_[0].exponents]
-
     for poly in polys_[1:]:
         global_exponents.extend([tuple(exponent)
                                  for exponent in poly.exponents
                                  if tuple(exponent) not in global_exponents])
+    global_exponents = numpy.vstack([poly.exponents for poly in polys_]) 
+    global_exponents = numpy.unique(global_exponents, axis=0).tolist()
 
     for idx, poly in enumerate(polys_):
+        if numpy.all(poly.exponents == global_exponents):
+            continue
         lookup = {
             tuple(exponent): coefficient
             for exponent, coefficient in zip(
@@ -217,7 +217,7 @@ def align_exponents(*polys: PolyLike) -> Tuple[ndpoly, ...]:
         }
 
         zeros = numpy.zeros(poly.shape, dtype=poly.dtype)
-        coefficients = [lookup.get(exponent, zeros)
+        coefficients = [lookup.get(tuple(exponent), zeros)
                         for exponent in global_exponents]
         polys_[idx] = poly.from_attributes(
             exponents=global_exponents,
@@ -254,12 +254,14 @@ def align_dtype(*polys: PolyLike) -> Tuple[ndpoly, ...]:
     polys_ = [numpoly.aspolynomial(poly) for poly in polys]
     dtype = numpy.asarray(numpy.sum(numpy.array([
         numpy.array(True, dtype=poly.dtype) for poly in polys_]))).dtype
-    polys_ = [numpoly.ndpoly.from_attributes(
-        exponents=poly.exponents,
-        coefficients=poly.coefficients,
-        names=poly.indeterminants,
-        dtype=dtype,
-        retain_coefficients=True,
-        retain_names=True,
-    ) for poly in polys_]
+    for idx, poly in enumerate(polys_):
+        if poly.dtype != dtype:
+            polys_[idx] = numpoly.ndpoly.from_attributes(
+                exponents=poly.exponents,
+                coefficients=poly.coefficients,
+                names=poly.indeterminants,
+                dtype=dtype,
+                retain_coefficients=True,
+                retain_names=True,
+            )
     return tuple(polys_)

--- a/numpoly/align.py
+++ b/numpoly/align.py
@@ -31,11 +31,11 @@ def align_polynomials(*polys: PolyLike) -> Tuple[ndpoly, ...]:
         [1]
         >>> q0.indeterminants
         polynomial([q0])
-        >>> q0, _ = numpoly.align_polynomials(q0, q0q1.astype(float))
+        >>> q0, _ = numpoly.align_polynomials(q0, q0q1)
         >>> q0
         polynomial([q0, q0])
         >>> q0.coefficients
-        [array([0., 0.]), array([1., 1.])]
+        [array([0, 0]), array([1, 1])]
         >>> q0.indeterminants
         polynomial([q0, q1])
 
@@ -44,7 +44,6 @@ def align_polynomials(*polys: PolyLike) -> Tuple[ndpoly, ...]:
     polys = align_shape(*polys)
     polys = align_indeterminants(*polys)
     polys = align_exponents(*polys)
-    polys = align_dtype(*polys)
     return polys
 
 
@@ -226,42 +225,4 @@ def align_exponents(*polys: PolyLike) -> Tuple[ndpoly, ...]:
             retain_coefficients=True,
             retain_names=True,
         )
-    return tuple(polys_)
-
-
-def align_dtype(*polys: PolyLike) -> Tuple[ndpoly, ...]:
-    """
-    Align polynomial by shape.
-
-    Args:
-        polys (numpoly.ndpoly):
-            Polynomial to make adjustment to.
-
-    Returns:
-        (Tuple[numpoly.ndpoly, ...]):
-            Same as ``polys``, but internal adjustments made to make them
-            compatible for further operations.
-
-    Examples:
-        >>> q0 = numpoly.variable()
-        >>> q0.dtype.name
-        'int64'
-        >>> poly, _ = numpoly.align_dtype(q0, 4.5)
-        >>> poly.dtype.name
-        'float64'
-
-    """
-    polys_ = [numpoly.aspolynomial(poly) for poly in polys]
-    dtype = numpy.asarray(numpy.sum(numpy.array([
-        numpy.array(True, dtype=poly.dtype) for poly in polys_]))).dtype
-    for idx, poly in enumerate(polys_):
-        if poly.dtype != dtype:
-            polys_[idx] = numpoly.ndpoly.from_attributes(
-                exponents=poly.exponents,
-                coefficients=poly.coefficients,
-                names=poly.indeterminants,
-                dtype=dtype,
-                retain_coefficients=True,
-                retain_names=True,
-            )
     return tuple(polys_)

--- a/numpoly/align.py
+++ b/numpoly/align.py
@@ -42,7 +42,7 @@ def align_polynomials(*polys: PolyLike) -> Tuple[ndpoly, ...]:
     """
     # polys = numpoly.broadcast_arrays(*polys)
     polys = align_shape(*polys)
-    polys = align_indeterminants(*polys)
+    # polys = align_indeterminants(*polys)
     polys = align_exponents(*polys)
     return polys
 

--- a/numpoly/array_function/apply_along_axis.py
+++ b/numpoly/array_function/apply_along_axis.py
@@ -100,9 +100,8 @@ def apply_along_axis(
     arr = numpoly.aspolynomial(arr)
     out = numpy.apply_along_axis(wrapper_func, axis=axis, arr=arr.values)
 
-    # align indeterminants and exponents
-    polynomials = numpoly.align.align_indeterminants(*collection)
-    polynomials = numpoly.align.align_exponents(*polynomials)
+    # align exponents
+    polynomials = numpoly.align.align_exponents(*collection)
     dtype = numpoly.result_type(*polynomials)
 
     # Store results into new array

--- a/numpoly/array_function/concatenate.py
+++ b/numpoly/array_function/concatenate.py
@@ -48,7 +48,19 @@ def concatenate(
 
     """
     arrays = numpoly.align_exponents(*arrays)
-    arrays = numpoly.align_dtype(*arrays)
-    result = numpy.concatenate(
-        [array.values for array in arrays], axis=axis, out=out)
-    return numpoly.aspolynomial(result, names=arrays[0].indeterminants)
+    if out is None:
+        coefficients = [numpy.concatenate(
+            [array.values[key] for array in arrays], axis=axis)
+                        for key in arrays[0].keys]
+        out = numpoly.polynomial_from_attributes(
+            exponents=arrays[0].exponents,
+            coefficients=coefficients,
+            names=arrays[0].names,
+            dtype=coefficients[0].dtype,
+        )
+    else:
+        for key in out.keys:
+            if key in arrays[0].keys:
+                numpy.concatenate([array.values[key] for array in arrays],
+                                  out=out.values[key], axis=axis)
+    return out

--- a/numpoly/array_function/diff.py
+++ b/numpoly/array_function/diff.py
@@ -63,14 +63,10 @@ def diff(
     """
     if append is not None:
         if prepend is not None:
-            a, append, prepend = numpoly.align_indeterminants(
-                a, append, prepend)
             a, append, prepend = numpoly.align_exponents(a, append, prepend)
         else:
-            a, append = numpoly.align_indeterminants(a, append)
             a, append = numpoly.align_exponents(a, append)
     elif prepend is not None:
-        a, prepend = numpoly.align_indeterminants(a, prepend)
         a, prepend = numpoly.align_exponents(a, prepend)
     else:
         a = numpoly.aspolynomial(a)

--- a/numpoly/array_function/dstack.py
+++ b/numpoly/array_function/dstack.py
@@ -49,6 +49,11 @@ def dstack(tup: Sequence[PolyLike]) -> ndpoly:
 
     """
     arrays = numpoly.align_exponents(*tup)
-    arrays = numpoly.align_dtype(*arrays)
-    result = numpy.dstack([array.values for array in arrays])
-    return numpoly.aspolynomial(result, names=arrays[0].indeterminants)
+    coefficients = [numpy.dstack([array.values[key] for array in arrays])
+                    for key in arrays[0].keys]
+    return numpoly.polynomial_from_attributes(
+        exponents=arrays[0].exponents,
+        coefficients=coefficients,
+        names=arrays[0].names,
+        dtype=coefficients[0].dtype,
+    )

--- a/numpoly/array_function/ediff1d.py
+++ b/numpoly/array_function/ediff1d.py
@@ -50,7 +50,6 @@ def ediff1d(
     arys = tuple(numpoly.aspolynomial(ary) for ary in arys_)
     if len(arys) > 1:
         arys = numpoly.align_exponents(*arys)
-        arys = numpoly.align_indeterminants(*arys)
 
     out = numpoly.ndpoly(
         exponents=arys[0].exponents,

--- a/numpoly/array_function/ediff1d.py
+++ b/numpoly/array_function/ediff1d.py
@@ -49,7 +49,6 @@ def ediff1d(
         arys_.insert(0, numpoly.aspolynomial(to_begin).ravel())
     arys = tuple(numpoly.aspolynomial(ary) for ary in arys_)
     if len(arys) > 1:
-        arys = numpoly.align_dtype(*arys)
         arys = numpoly.align_exponents(*arys)
         arys = numpoly.align_indeterminants(*arys)
 

--- a/numpoly/array_function/hstack.py
+++ b/numpoly/array_function/hstack.py
@@ -45,7 +45,11 @@ def hstack(tup: Sequence[PolyLike]) -> ndpoly:
 
     """
     arrays = numpoly.align_exponents(*tup)
-    arrays = numpoly.align_dtype(*arrays)
-    result = numpy.hstack([array.values for array in arrays])
-    return numpoly.aspolynomial(
-        result, names=arrays[0].indeterminants)
+    coefficients = [numpy.hstack([array.values[key] for array in arrays])
+                    for key in arrays[0].keys]
+    return numpoly.polynomial_from_attributes(
+        exponents=arrays[0].exponents,
+        coefficients=coefficients,
+        names=arrays[0].names,
+        dtype=coefficients[0].dtype,
+    )

--- a/numpoly/array_function/not_equal.py
+++ b/numpoly/array_function/not_equal.py
@@ -55,7 +55,12 @@ def not_equal(
                [ True, False]])
 
     """
-    x1, x2 = numpoly.align_polynomials(x1, x2)
+    x1, x2 = numpoly.align_exponents(x1, x2)
+    if not x1.flags["OWNDATA"]:
+        x1 = numpoly.polynomial(x1)
+    if not x2.flags["OWNDATA"]:
+        x2 = numpoly.polynomial(x2)
+    # x1, x2 = numpoly.align_polynomials(x1, x2)
     where = numpy.asarray(where)
     for key in x1.keys:
         tmp = numpy.not_equal(

--- a/numpoly/array_function/stack.py
+++ b/numpoly/array_function/stack.py
@@ -49,8 +49,19 @@ def stack(
 
     """
     arrays = numpoly.align_exponents(*arrays)
-    arrays = numpoly.align_dtype(*arrays)
-    result = numpy.stack(
-        [array.values for array in arrays], axis=axis, out=out)
-    return numpoly.aspolynomial(result, names=arrays[0].indeterminants)
-
+    if out is None:
+        coefficients = [numpy.stack(
+            [array.values[key] for array in arrays], axis=axis)
+                        for key in arrays[0].keys]
+        out = numpoly.polynomial_from_attributes(
+            exponents=arrays[0].exponents,
+            coefficients=coefficients,
+            names=arrays[0].names,
+            dtype=coefficients[0].dtype,
+        )
+    else:
+        for key in out.keys:
+            if key in arrays[0].keys:
+                numpy.stack([array.values[key] for array in arrays],
+                            out=out.values[key], axis=axis)
+    return out

--- a/numpoly/array_function/vstack.py
+++ b/numpoly/array_function/vstack.py
@@ -49,6 +49,11 @@ def vstack(tup: Sequence[PolyLike]) -> ndpoly:
 
     """
     arrays = numpoly.align_exponents(*tup)
-    arrays = numpoly.align_dtype(*arrays)
-    result = numpy.vstack([array.values for array in arrays])
-    return numpoly.aspolynomial(result, names=arrays[0].indeterminants)
+    coefficients = [numpy.vstack([array.values[key] for array in arrays])
+                    for key in arrays[0].keys]
+    return numpoly.polynomial_from_attributes(
+        exponents=arrays[0].exponents,
+        coefficients=coefficients,
+        names=arrays[0].names,
+        dtype=coefficients[0].dtype,
+    )

--- a/numpoly/array_function/where.py
+++ b/numpoly/array_function/where.py
@@ -51,6 +51,12 @@ def where(condition: numpy.typing.ArrayLike, *args: PolyLike) -> ndpoly:
         return numpy.where(condition)
 
     poly1, poly2 = numpoly.align_polynomials(*args)
-    out = numpy.where(condition, poly1.values, poly2.values)
-    out = numpoly.polynomial(out, names=poly1.indeterminants)
-    return out
+    coefficients = [numpy.where(condition, x1, x2)
+                    for x1, x2 in zip(poly1.coefficients, poly2.coefficients)]
+    dtype = numpy.result_type(poly1.dtype, poly2.dtype)
+    return numpoly.polynomial_from_attributes(
+        exponents=poly1.exponents,
+        coefficients=coefficients,
+        names=poly1.names,
+        dtype=dtype,
+    )

--- a/numpoly/baseclass.py
+++ b/numpoly/baseclass.py
@@ -657,8 +657,6 @@ as numpy.loadtxt will not work as expected.""")
 
     def __ne__(self, other: object) -> numpy.ndarray:  # type: ignore
         """Not equal."""
-        other = numpoly.polynomial(other)
-        self = numpoly.polynomial(self)
         return numpoly.not_equal(self, other)
 
     def __repr__(self) -> str:

--- a/numpoly/baseclass.py
+++ b/numpoly/baseclass.py
@@ -15,7 +15,7 @@ structured array directly using the ``values`` attribute:
     >>> poly = numpoly.polynomial(4*q0+3*q1-1)
     >>> array = poly.values
     >>> array
-    array((4, 3, -1), dtype=[('<;', '<i8'), (';<', '<i8'), (';;', '<i8')])
+    array((-1, 3, 4), dtype=[(';;', '<i8'), (';<', '<i8'), ('<;', '<i8')])
 
 Which, together with the indeterminant names, can be used to cast back the
 array back to a polynomial:
@@ -548,6 +548,16 @@ as numpy.loadtxt will not work as expected.""")
         return numpoly.min(self, axis=axis, out=out,
                            keepdims=keepdims, **kwargs)
 
+    def mean(  # type: ignore
+        self,
+        axis: Union[None, int, Sequence[int]] = None,
+        dtype: Optional[numpy.typing.DTypeLike] = None,
+        out: Optional[ndpoly] = None,
+        **kwargs: Any,
+    ) -> "ndpoly":
+        """Wrap ndarray.mean."""
+        return numpoly.mean(self, axis=axis, dtype=dtype, out=out, **kwargs)
+
     # ============================================================
     # Override dunder methods that isn't dealt with by dispatching
     # ============================================================
@@ -647,6 +657,8 @@ as numpy.loadtxt will not work as expected.""")
 
     def __ne__(self, other: object) -> numpy.ndarray:  # type: ignore
         """Not equal."""
+        other = numpoly.polynomial(other)
+        self = numpoly.polynomial(self)
         return numpoly.not_equal(self, other)
 
     def __repr__(self) -> str:

--- a/numpoly/construct/clean.py
+++ b/numpoly/construct/clean.py
@@ -42,8 +42,8 @@ def clean_attributes(
         >>> q0.indeterminants
         polynomial([q0, q1])
         >>> q0.exponents
-        array([[1, 0],
-               [0, 1]], dtype=uint32)
+        array([[0, 1],
+               [1, 0]], dtype=uint32)
         >>> q0 = numpoly.clean_attributes(
         ...     q0, retain_coefficients=False, retain_names=False)
         >>> q0.indeterminants

--- a/numpoly/dispatch.py
+++ b/numpoly/dispatch.py
@@ -80,7 +80,7 @@ def simple_dispatch(
 
     """
     inputs = numpoly.align_polynomials(*inputs)
-    keys = numpoly.aspolynomial(inputs[0] if out is None else out[0]).keys
+    keys = (inputs[0] if out is None else numpoly.aspolynomial(out[0])).keys
 
     tmp = numpy_func(*[poly.values[keys[0]]for poly in inputs], **kwargs)
     if out is None:

--- a/numpoly/poly_function/divide/divmod.py
+++ b/numpoly/poly_function/divide/divmod.py
@@ -77,7 +77,7 @@ def poly_divmod(
 
     if not dividend_.shape:
         floor, remainder = poly_divmod(
-            dividend_.flatten(), divisor.flatten(),
+            dividend_.ravel(), divisor.ravel(),
             out=out, where=where, **kwargs,
         )
         return floor[0], remainder[0]
@@ -95,7 +95,6 @@ def poly_divmod(
             divisor.indeterminants**exponent_diff, 0)
         key = dividend_.keys[idx1]
 
-        # iterate division algorithm
         quotient = numpoly.add(
             quotient, numpoly.where(include, candidate, 0), **kwargs)
         dividend_ = numpoly.subtract(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "numpoly"
-version = "1.2.2"
+version = "1.2.3"
 description = "Polynomials as a numpy datatype"
 license = "BSD-2-Clause"
 authors = ["Jonathan Feinberg"]

--- a/test/test_align.py
+++ b/test/test_align.py
@@ -15,7 +15,6 @@ def test_align_polynomials():
     assert numpy.all(poly1_.exponents == poly2_.exponents)
     assert poly1_.exponents.shape[-1] == 2
     assert poly1_.shape == poly2_.shape
-    assert poly1_.dtype == poly2_.dtype
 
     X_, Y_ = numpoly.align_polynomials(X, Y)
     assert not X_.shape

--- a/test/test_array_function.py
+++ b/test/test_array_function.py
@@ -33,11 +33,12 @@ def assert_equal(results, reference, c_contiguous=None,
 
     """
     if type_ is None:
-        assert isinstance(results, (bool, numpy.bool_, numpy.number, numpy.ndarray)), (
-            "unrecognized results type: %s" % results)
+        assert isinstance(
+            results, (bool, numpy.bool_, numpy.number, numpy.ndarray)), (
+                f"unrecognized results type: {results}")
     else:
         assert isinstance(results, type_), (
-            "invalid results type: %s != %s" % (results, type_))
+            f"invalid results type: {results} != {type_}")
     if isinstance(results, numpoly.ndpoly):
         reference = numpoly.aspolynomial(reference)
     else:
@@ -45,27 +46,28 @@ def assert_equal(results, reference, c_contiguous=None,
         reference = numpy.asarray(reference)
 
     assert results.shape == reference.shape, (
-        "shape mismatch: %s != %s" % (results, reference))
+        f"shape mismatch: {results} != {reference}")
     assert results.dtype == reference.dtype, (
-        "dtype mismatch: %s != %s" % (results, reference))
+        f"dtype mismatch: {results} != {reference}")
 
     if not isinstance(results, numpoly.ndpoly):
-        assert numpy.allclose(results, reference)
+        assert numpy.allclose(results, reference), (
+            f"value mismatch: {results} != {reference}")
     elif results.shape:
         assert numpy.all(results == reference), (
-            "value mismatch: %s != %s" % (results, reference))
+            f"value mismatch: {results} != {reference}")
     else:
         assert results == reference, (
-            "value mismatch: %s != %s" % (results, reference))
+            f"value mismatch: {results} != {reference}")
 
     if c_contiguous is None:
         c_contiguous = reference.flags["C_CONTIGUOUS"]
     assert results.flags["C_CONTIGUOUS"] == c_contiguous, (
-        "c_contiguous mismatch: %s != %s" % (results, reference))
+        f"c_contiguous mismatch: {results} != {reference}")
     if f_contiguous is None:
         f_contiguous = reference.flags["F_CONTIGUOUS"]
     assert results.flags["F_CONTIGUOUS"] == f_contiguous, (
-        "f_contiguous mismatch: %s != %s" % (results, reference))
+        f"f_contiguous mismatch: {results} != {reference}")
 
 
 def test_absolute(interface):
@@ -80,7 +82,8 @@ def test_add(interface):
     assert_equal(interface.add(X, 3), 3+X)
     assert_equal(interface.add(polynomial([1, X, Y]), 4), [5, 4+X, 4+Y])
     assert_equal(interface.add(polynomial([0, X]), polynomial([Y, 0])), [Y, X])
-    assert_equal(interface.add(polynomial([[1, X], [Y, X*Y]]), [2, X]), [[3, 2*X], [2+Y, X+X*Y]])
+    assert_equal(interface.add(polynomial(
+        [[1, X], [Y, X*Y]]), [2, X]), [[3, 2*X], [2+Y, X+X*Y]])
 
 
 def test_any(interface):
@@ -88,7 +91,8 @@ def test_any(interface):
     poly = polynomial([[0, Y], [0, 0]])
     assert_equal(interface.any(poly), True)
     assert_equal(interface.any(poly, axis=0), [False, True])
-    assert_equal(interface.any(poly, axis=-1, keepdims=True), [[True], [False]])
+    assert_equal(
+        interface.any(poly, axis=-1, keepdims=True), [[True], [False]])
 
 
 def test_all(interface):
@@ -96,7 +100,8 @@ def test_all(interface):
     poly = polynomial([[0, Y], [X, 1]])
     assert_equal(interface.all(poly), False)
     assert_equal(interface.all(poly, axis=0), [False, True])
-    assert_equal(interface.all(poly, axis=-1, keepdims=True), [[False], [True]])
+    assert_equal(
+        interface.all(poly, axis=-1, keepdims=True), [[False], [True]])
 
 
 def test_allclose(func_interface):
@@ -162,21 +167,33 @@ def test_argmin(func_interface):
 def test_apply_along_axis(func_interface):
     """Tests for numpoly.apply_along_axis."""
     np_array = numpy.arange(9, dtype=int).reshape(3, 3)
-    assert_equal(func_interface.apply_along_axis(numpy.sum, 0, np_array), [9, 12, 15])
-    assert_equal(func_interface.apply_along_axis(numpy.sum, 1, np_array), [3, 12, 21])
+    assert_equal(
+        func_interface.apply_along_axis(numpy.sum, 0, np_array), [9, 12, 15])
+    assert_equal(
+        func_interface.apply_along_axis(numpy.sum, 1, np_array), [3, 12, 21])
     poly1 = numpoly.polynomial([[X, X, X], [Y, Y, Y], [1, 2, 3]])
-    assert_equal(func_interface.apply_along_axis(numpoly.sum, 0, poly1), [X+Y+1, X+Y+2, X+Y+3])
-    assert_equal(func_interface.apply_along_axis(numpoly.sum, 1, poly1), [3*X, 3*Y, 6])
+    assert_equal(
+        func_interface.apply_along_axis(numpoly.sum, 0, poly1),
+        [X+Y+1, X+Y+2, X+Y+3])
+    assert_equal(
+        func_interface.apply_along_axis(numpoly.sum, 1, poly1), [3*X, 3*Y, 6])
 
 
 def test_apply_over_axes(func_interface):
     """Tests for numpoly.apply_over_axes."""
     np_array = numpy.arange(9).reshape(3, 3)
-    assert_equal(func_interface.apply_over_axes(numpy.sum, np_array, 0), [[9, 12, 15]])
-    assert_equal(func_interface.apply_over_axes(numpy.sum, np_array, 1), [[3], [12], [21]])
+    assert_equal(
+        func_interface.apply_over_axes(numpy.sum, np_array, 0), [[9, 12, 15]])
+    assert_equal(
+        func_interface.apply_over_axes(numpy.sum, np_array, 1),
+        [[3], [12], [21]])
     poly1 = numpoly.polynomial([[X, X, X], [Y, Y, Y], [1, 2, 3]])
-    assert_equal(func_interface.apply_over_axes(numpoly.sum, poly1, 0), [[X+Y+1, X+Y+2, X+Y+3]])
-    assert_equal(func_interface.apply_over_axes(numpoly.sum, poly1, 1), [[3*X], [3*Y], [6]])
+    assert_equal(
+        func_interface.apply_over_axes(
+            numpoly.sum, poly1, 0), [[X+Y+1, X+Y+2, X+Y+3]])
+    assert_equal(
+        func_interface.apply_over_axes(
+            numpoly.sum, poly1, 1), [[3*X], [3*Y], [6]])
 
 
 def test_around(interface):
@@ -222,7 +239,8 @@ def test_array_str(func_interface):
     assert str(4+6*X**2) == "6*q0**2+4"
     assert func_interface.array_str(4+6*X**2) == "6*q0**2+4"
     assert str(polynomial([1., -5*X, 3-X**2])) == "[1.0 -5.0*q0 -q0**2+3.0]"
-    assert func_interface.array_str(polynomial([1., -5*X, 3-X**2])) == "[1.0 -5.0*q0 -q0**2+3.0]"
+    assert func_interface.array_str(
+        polynomial([1., -5*X, 3-X**2])) == "[1.0 -5.0*q0 -q0**2+3.0]"
     assert str(polynomial([[[1, 2], [5, Y]]])) == """\
 [[[1 2]
   [5 q1]]]"""
@@ -286,9 +304,11 @@ def test_ceil(func_interface):
 
 def test_common_type(func_interface):
     """Tests for numpoly.common_type."""
-    assert func_interface.common_type(numpy.array(2, dtype=numpy.float32)) == numpy.float32
+    assert func_interface.common_type(
+        numpy.array(2, dtype=numpy.float32)) == numpy.float32
     assert func_interface.common_type(X) == numpy.float64
-    assert func_interface.common_type(numpy.arange(3), 1j*X, 45) == numpy.complex128
+    assert func_interface.common_type(
+        numpy.arange(3), 1j*X, 45) == numpy.complex128
 
 
 def test_concatenate(func_interface):
@@ -325,7 +345,8 @@ def test_copyto(func_interface):
     poly = numpoly.polynomial([1, 2, 3])
     func_interface.copyto(poly, [3, 2, 1], casting="unsafe")
     assert_equal(poly, [3, 2, 1])
-    func_interface.copyto(poly.values, numpoly.polynomial([1, 2, 3]), casting="unsafe")
+    func_interface.copyto(
+        poly.values, numpoly.polynomial([1, 2, 3]), casting="unsafe")
     assert_equal(poly, [1, 2, 3])
     out = numpy.zeros(3, dtype=float)
     numpoly.copyto(out, poly, casting="unsafe")
@@ -356,7 +377,8 @@ def test_det():
     poly = polynomial([[1, Y], [X, 1]])
     assert_equal(numpoly.det([array, poly]), [-2, 1-X*Y])
     assert_equal(numpy.linalg.det(poly), 1-X*Y)
-    assert_equal(numpoly.det([[1, X, Y], [Y, 1, X], [X, Y, 1]]), X**3+Y**3-3*X*Y+1)
+    assert_equal(
+        numpoly.det([[1, X, Y], [Y, 1, X], [X, Y, 1]]), X**3+Y**3-3*X*Y+1)
 
 
 def test_diag(func_interface):
@@ -405,7 +427,7 @@ def test_diff(func_interface):
     assert_equal(func_interface.diff(poly, n=2),
                  [[X-3], [10-2*Y], [X+Y-9]])
     assert_equal(func_interface.diff(poly, axis=0),
-                 [[3, Y-2, 6-X,], [3, 8-Y, X+Y-6]])
+                 [[3, Y-2, 6-X], [3, 8-Y, X+Y-6]])
     assert_equal(func_interface.diff(poly, append=X),
                  [[1, X-2, 0], [Y-4, 6-Y, X-6], [1, X+Y-8, -Y]])
     assert_equal(func_interface.diff(poly, prepend=Y),
@@ -488,7 +510,8 @@ def test_floor_divide(interface):
     poly = polynomial([[0., 2.*Y], [X, 2.]])
     assert_equal(interface.floor_divide(poly, 2), [[0., Y], [0., 1]])
     assert_equal(interface.floor_divide(poly, [1., 2.]), [[0., Y], [X, 1]])
-    assert_equal(interface.floor_divide(poly, [[1., 2.], [2., 1.]]), [[0., Y], [0., 2.]])
+    assert_equal(interface.floor_divide(
+        poly, [[1., 2.], [2., 1.]]), [[0., Y], [0., 2.]])
     with raises(numpoly.FeatureNotSupported):
         interface.floor_divide(poly, X)
     with raises(numpoly.FeatureNotSupported):
@@ -509,7 +532,8 @@ def test_floor_divide(interface):
 def test_full(func_interface):
     """Tests for numpoly.full."""
     assert_equal(numpoly.full((3,), X), [X, X, X])
-    assert_equal(numpoly.aspolynomial(func_interface.full((3,), 1.*X)), [1.*X, X, X])
+    assert_equal(numpoly.aspolynomial(
+        func_interface.full((3,), 1.*X)), [1.*X, X, X])
     assert_equal(numpoly.full((3,), Y, dtype=float), [1.*Y, Y, Y])
     if func_interface is numpy:  # fails in numpy, but only with func dispatch.
         with raises(ValueError, ):
@@ -557,7 +581,7 @@ def test_greater_equal(interface):
                   [True, True, True, True]])
     assert_equal(interface.greater_equal(poly, Y),
                  [[False, False, False, True],
-                  [ True, False, True, False],
+                  [True, False, True, False],
                   [False, True, False, False],
                   [True, True, True, False]])
 
@@ -674,8 +698,10 @@ def test_matmul(func_interface):
     """Tests for numpoly.matmul."""
     poly1 = numpoly.polynomial([[0, X], [1, Y]])
     poly2 = numpoly.polynomial([X, 2])
-    assert_equal(func_interface.matmul(poly1, poly2), [[X**2, 2*X], [X+X*Y, 2+2*Y]])
-    assert_equal(func_interface.matmul(numpy.ones((2, 5, 6, 4)), numpy.ones((2, 5, 4, 3))),
+    assert_equal(func_interface.matmul(
+        poly1, poly2), [[X**2, 2*X], [X+X*Y, 2+2*Y]])
+    assert_equal(func_interface.matmul(
+        numpy.ones((2, 5, 6, 4)), numpy.ones((2, 5, 4, 3))),
                  4*numpy.ones((2, 5, 6, 3)))
     with raises(ValueError):
         func_interface.matmul(poly1, 4)
@@ -763,7 +789,8 @@ def test_multiply(func_interface):
     assert_equal([X, 1]*poly, [[0, 2+Y], [X*X, 2]])
     assert_equal(func_interface.multiply([X, 1], poly), [[0, 2+Y], [X*X, 2]])
     assert_equal([[X, 1], [Y, 0]]*poly, [[0, 2+Y], [X*Y, 0]])
-    assert_equal(func_interface.multiply([[X, 1], [Y, 0]], poly), [[0, 2+Y], [X*Y, 0]])
+    assert_equal(
+        func_interface.multiply([[X, 1], [Y, 0]], poly), [[0, 2+Y], [X*Y, 0]])
 
 
 def test_negative(func_interface):
@@ -791,7 +818,8 @@ def test_not_equal(interface):
     assert_equal((X != poly), [[True, True], [False, True]])
     assert_equal(interface.not_equal(X, poly), [[True, True], [False, True]])
     assert_equal(poly != poly.T, [[False, True], [True, False]])
-    assert_equal(interface.not_equal(poly, poly.T), [[False, True], [True, False]])
+    assert_equal(
+        interface.not_equal(poly, poly.T), [[False, True], [True, False]])
 
 
 def test_ones_like(func_interface):
@@ -830,13 +858,15 @@ def test_power(func_interface):
     assert_equal(polynomial([X])**[1, 2], [X, X**2])
     assert_equal(func_interface.power(polynomial([X]), [1, 2]), [X, X**2])
     assert_equal((X*Y)**[0, 1, 2, 3], [1, X*Y, X**2*Y**2, X**3*Y**3])
-    assert_equal(func_interface.power(X*Y, [0, 1, 2, 3]), [1, X*Y, X**2*Y**2, X**3*Y**3])
+    assert_equal(func_interface.power(
+        X*Y, [0, 1, 2, 3]), [1, X*Y, X**2*Y**2, X**3*Y**3])
     assert_equal(poly ** 2, [[0, Y**2], [X*X-2*X+1, 4]])
     assert_equal(func_interface.power(poly, 2), [[0, Y**2], [X*X-2*X+1, 4]])
     assert_equal(poly ** [1, 2], [[0, Y**2], [X-1, 4]])
     assert_equal(func_interface.power(poly, [1, 2]), [[0, Y**2], [X-1, 4]])
     assert_equal(poly ** [[1, 2], [2, 1]], [[0, Y**2], [X*X-2*X+1, 2]])
-    assert_equal(func_interface.power(poly, [[1, 2], [2, 1]]), [[0, Y**2], [X*X-2*X+1, 2]])
+    assert_equal(func_interface.power(
+        poly, [[1, 2], [2, 1]]), [[0, Y**2], [X*X-2*X+1, 2]])
 
 
 def test_prod(interface):
@@ -930,21 +960,25 @@ def test_square(func_interface):
 def test_stack(func_interface):
     """Tests for numpoly.stack."""
     poly = polynomial([1, X, Y])
-    assert_equal(func_interface.stack([poly, poly], axis=0), [[1, X, Y], [1, X, Y]])
-    assert_equal(func_interface.stack([poly, poly], axis=1), [[1, 1], [X, X], [Y, Y]])
+    assert_equal(
+        func_interface.stack([poly, poly], axis=0), [[1, X, Y], [1, X, Y]])
+    assert_equal(
+        func_interface.stack([poly, poly], axis=1), [[1, 1], [X, X], [Y, Y]])
 
 
 def test_subtract(func_interface):
     """Tests for numpoly.subtract."""
     assert_equal(-X+3, 3-X)
     assert_equal(4 - polynomial([1, X, Y]), [3, 4-X, 4-Y])
-    assert_equal(func_interface.subtract(4, polynomial([1, X, Y])), [3, 4-X, 4-Y])
+    assert_equal(
+        func_interface.subtract(4, polynomial([1, X, Y])), [3, 4-X, 4-Y])
     assert_equal(polynomial([0, X]) - polynomial([Y, 0]), [-Y, X])
     assert_equal(func_interface.subtract(polynomial([0, X]), [Y, 0]), [-Y, X])
     assert_equal(polynomial([[1, X], [Y, X*Y]]) - [2, X],
                  [[-1, 0], [Y-2, X*Y-X]])
-    assert_equal(func_interface.subtract(polynomial([[1, X], [Y, X*Y]]), [2, X]),
-                 [[-1, 0], [Y-2, X*Y-X]])
+    assert_equal(
+        func_interface.subtract(polynomial([[1, X], [Y, X*Y]]), [2, X]),
+        [[-1, 0], [Y-2, X*Y-X]])
 
 
 def test_sum(interface):
@@ -952,7 +986,8 @@ def test_sum(interface):
     poly = polynomial([[1, 5*X], [X+3, -Y]])
     assert_equal(interface.sum(poly), -Y+X*6+4)
     assert_equal(interface.sum(poly, axis=0), [X+4, -Y+X*5])
-    assert_equal(interface.sum(poly, axis=-1, keepdims=True), [[X*5+1], [X-Y+3]])
+    assert_equal(
+        interface.sum(poly, axis=-1, keepdims=True), [[X*5+1], [X-Y+3]])
 
 
 def test_transpose(func_interface):
@@ -960,15 +995,19 @@ def test_transpose(func_interface):
     poly = numpoly.polynomial([[1, X-1], [X**2, X]])
     assert_equal(func_interface.transpose(poly),
                  [[1, X**2], [X-1, X]])
-    assert_equal(poly.T, [[1, X**2], [X-1, X]], c_contiguous=False, f_contiguous=True)
+    assert_equal(
+        poly.T, [[1, X**2], [X-1, X]], c_contiguous=False, f_contiguous=True)
 
 
 def test_true_divide(func_interface):
     """Tests for numpoly.true_divide."""
     poly = polynomial([[0, Y], [X, 1]])
-    assert_equal(func_interface.true_divide(poly, 2), polynomial([[0, 0.5*Y], [0.5*X, 0.5]]))
-    assert_equal(func_interface.true_divide(poly, [1, 2]), [[0, 0.5*Y], [X, 0.5]])
-    assert_equal(func_interface.true_divide(poly, [[1, 2], [2, 1]]), [[0, 0.5*Y], [0.5*X, 1]])
+    assert_equal(func_interface.true_divide(
+        poly, 2), polynomial([[0, 0.5*Y], [0.5*X, 0.5]]))
+    assert_equal(func_interface.true_divide(
+        poly, [1, 2]), [[0, 0.5*Y], [X, 0.5]])
+    assert_equal(func_interface.true_divide(
+        poly, [[1, 2], [2, 1]]), [[0, 0.5*Y], [0.5*X, 1]])
     with raises(numpoly.FeatureNotSupported):
         func_interface.true_divide(poly, X)
 


### PR DESCRIPTION
When arrays get big, doing repeated aligns (i.e. array reinitializations) becomes costly.
Not doing so means lots of arrays becomes numpy views, which requires a bit more manual hand holding of the code addressing various edge cases.

Hopefully this will reduce memory copying enough to notice some speed improvements.