### PR TITLE
Remove reference to `numpy.product`

### DIFF
--- a/numpoly/array_function/prod.py
+++ b/numpoly/array_function/prod.py
@@ -10,7 +10,7 @@ from ..baseclass import ndpoly, PolyLike
 from ..dispatch import implements
 
 
-@implements(numpy.prod, numpy.product)
+@implements(numpy.prod)
 def prod(
     a: PolyLike,
     axis: Union[None, int, Sequence[int]] = None,


### PR DESCRIPTION
Hi!

`numpy.product` is [depreciated](https://numpy.org/doc/stable/release/1.25.0-notes.html) and importing numpoly with numpy 2.0.0 nor raises an error:

   https://github.com/gboehl/pydsge/actions/runs/9542499274/job/26297409742

Simple fix is to remove the reference. 

Cheers!

